### PR TITLE
Blockstorage: Dont access gArgs in blockmanager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,6 +173,7 @@ BITCOIN_CORE_H = \
   interfaces/ipc.h \
   interfaces/node.h \
   interfaces/wallet.h \
+  kernel/blockmanager_opts.h \
   kernel/chain.h \
   kernel/chainstatemanager_opts.h \
   kernel/checks.h \
@@ -199,6 +200,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   netgroup.h \
   netmessagemaker.h \
+  node/blockmanager_args.h \
   node/blockstorage.h \
   node/caches.h \
   node/chainstate.h \
@@ -383,6 +385,7 @@ libbitcoin_node_a_SOURCES = \
   net.cpp \
   net_processing.cpp \
   netgroup.cpp \
+  node/blockmanager_args.cpp \
   node/blockstorage.cpp \
   node/caches.cpp \
   node/chainstate.cpp \

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -83,6 +83,7 @@ int main(int argc, char* argv[])
     const ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .adjusted_time_callback = NodeClock::now,
+        .blocks_dir = abs_datadir / "blocks",
     };
     ChainstateManager chainman{chainman_opts};
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -83,9 +83,11 @@ int main(int argc, char* argv[])
     const ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .adjusted_time_callback = NodeClock::now,
+    };
+    const node::BlockManager::Options blockman_opts{
         .blocks_dir = abs_datadir / "blocks",
     };
-    ChainstateManager chainman{chainman_opts};
+    ChainstateManager chainman{chainman_opts, blockman_opts};
 
     node::CacheSizes cache_sizes;
     cache_sizes.block_tree_db = 2 << 20;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -21,8 +21,6 @@
 #include <string>
 #include <utility>
 
-using node::ReadBlockFromDisk;
-
 constexpr uint8_t DB_BEST_BLOCK{'B'};
 
 constexpr auto SYNC_LOG_INTERVAL{30s};
@@ -199,7 +197,7 @@ void BaseIndex::ThreadSync()
 
             CBlock block;
             interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex);
-            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), m_chainstate->FastPrune(), block, pindex, consensus_params)) {
+            if (!m_chainstate->m_blockman.ReadBlockFromDisk(block, pindex, consensus_params)) {
                 FatalError("%s: Failed to read block %s from disk",
                            __func__, pindex->GetBlockHash().ToString());
                 return;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -199,7 +199,7 @@ void BaseIndex::ThreadSync()
 
             CBlock block;
             interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex);
-            if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
+            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), block, pindex, consensus_params)) {
                 FatalError("%s: Failed to read block %s from disk",
                            __func__, pindex->GetBlockHash().ToString());
                 return;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -199,7 +199,7 @@ void BaseIndex::ThreadSync()
 
             CBlock block;
             interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex);
-            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), block, pindex, consensus_params)) {
+            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), m_chainstate->FastPrune(), block, pindex, consensus_params)) {
                 FatalError("%s: Failed to read block %s from disk",
                            __func__, pindex->GetBlockHash().ToString());
                 return;

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -222,7 +222,7 @@ bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
         // pindex variable gives indexing code access to node internals. It
         // will be removed in upcoming commit
         const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
-        if (!UndoReadFromDisk(block_undo, pindex)) {
+        if (!UndoReadFromDisk(m_chainstate->BlocksDirPath(), block_undo, pindex)) {
             return false;
         }
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -11,8 +11,6 @@
 #include <util/system.h>
 #include <validation.h>
 
-using node::UndoReadFromDisk;
-
 /* The index database stores three items for each block: the disk location of the encoded filter,
  * its dSHA256 hash, and the header. Those belonging to blocks on the active chain are indexed by
  * height, and those belonging to blocks that have been reorganized out of the active chain are
@@ -222,7 +220,7 @@ bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
         // pindex variable gives indexing code access to node internals. It
         // will be removed in upcoming commit
         const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
-        if (!UndoReadFromDisk(m_chainstate->BlocksDirPath(), block_undo, pindex)) {
+        if (!m_chainstate->m_blockman.UndoReadFromDisk(block_undo, pindex)) {
             return false;
         }
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -124,7 +124,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
         // pindex variable gives indexing code access to node internals. It
         // will be removed in upcoming commit
         const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
-        if (!UndoReadFromDisk(block_undo, pindex)) {
+        if (!UndoReadFromDisk(m_chainstate->BlocksDirPath(), block_undo, pindex)) {
             return false;
         }
 
@@ -286,7 +286,7 @@ bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
         do {
             CBlock block;
 
-            if (!ReadBlockFromDisk(block, iter_tip, consensus_params)) {
+            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), block, iter_tip, consensus_params)) {
                 return error("%s: Failed to read block %s from disk",
                              __func__, iter_tip->GetBlockHash().ToString());
             }
@@ -408,7 +408,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
 
     // Ignore genesis block
     if (pindex->nHeight > 0) {
-        if (!UndoReadFromDisk(block_undo, pindex)) {
+        if (!UndoReadFromDisk(m_chainstate->BlocksDirPath(), block_undo, pindex)) {
             return false;
         }
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -18,8 +18,6 @@ using kernel::CCoinsStats;
 using kernel::GetBogoSize;
 using kernel::TxOutSer;
 
-using node::ReadBlockFromDisk;
-
 static constexpr uint8_t DB_BLOCK_HASH{'s'};
 static constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
 static constexpr uint8_t DB_MUHASH{'M'};
@@ -285,7 +283,7 @@ bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
         do {
             CBlock block;
 
-            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), m_chainstate->FastPrune(), block, iter_tip, consensus_params)) {
+            if (!m_chainstate->m_blockman.ReadBlockFromDisk(block, iter_tip, consensus_params)) {
                 return error("%s: Failed to read block %s from disk",
                              __func__, iter_tip->GetBlockHash().ToString());
             }

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -286,7 +286,7 @@ bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
         do {
             CBlock block;
 
-            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), block, iter_tip, consensus_params)) {
+            if (!ReadBlockFromDisk(m_chainstate->BlocksDirPath(), m_chainstate->FastPrune(), block, iter_tip, consensus_params)) {
                 return error("%s: Failed to read block %s from disk",
                              __func__, iter_tip->GetBlockHash().ToString());
             }

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -19,7 +19,6 @@ using kernel::GetBogoSize;
 using kernel::TxOutSer;
 
 using node::ReadBlockFromDisk;
-using node::UndoReadFromDisk;
 
 static constexpr uint8_t DB_BLOCK_HASH{'s'};
 static constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
@@ -124,7 +123,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
         // pindex variable gives indexing code access to node internals. It
         // will be removed in upcoming commit
         const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
-        if (!UndoReadFromDisk(m_chainstate->BlocksDirPath(), block_undo, pindex)) {
+        if (!m_chainstate->m_blockman.UndoReadFromDisk(block_undo, pindex)) {
             return false;
         }
 
@@ -408,7 +407,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
 
     // Ignore genesis block
     if (pindex->nHeight > 0) {
-        if (!UndoReadFromDisk(m_chainstate->BlocksDirPath(), block_undo, pindex)) {
+        if (!m_chainstate->m_blockman.UndoReadFromDisk(block_undo, pindex)) {
             return false;
         }
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -79,7 +79,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         return false;
     }
 
-    CAutoFile file(OpenBlockFile(m_chainstate->BlocksDirPath(), m_chainstate->FastPrune(), postx, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile file(m_chainstate->m_blockman.OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
     if (file.IsNull()) {
         return error("%s: OpenBlockFile failed", __func__);
     }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -79,7 +79,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         return false;
     }
 
-    CAutoFile file(OpenBlockFile(m_chainstate->BlocksDirPath(), postx, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile file(OpenBlockFile(m_chainstate->BlocksDirPath(), m_chainstate->FastPrune(), postx, true), SER_DISK, CLIENT_VERSION);
     if (file.IsNull()) {
         return error("%s: OpenBlockFile failed", __func__);
     }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -79,7 +79,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         return false;
     }
 
-    CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile file(OpenBlockFile(m_chainstate->BlocksDirPath(), postx, true), SER_DISK, CLIENT_VERSION);
     if (file.IsNull()) {
         return error("%s: OpenBlockFile failed", __func__);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1046,6 +1046,7 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
     {
         ChainstateManager::Options chainman_opts_dummy{
             .chainparams = chainparams,
+            .blocks_dir = gArgs.GetBlocksDirPath(),
         };
         if (const auto error{ApplyArgsManOptions(args, chainman_opts_dummy)}) {
             return InitError(*error);
@@ -1445,6 +1446,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .adjusted_time_callback = GetAdjustedTime,
+        .blocks_dir = gArgs.GetBlocksDirPath(),
     };
     Assert(!ApplyArgsManOptions(args, chainman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -36,6 +36,7 @@ struct ChainstateManagerOpts {
     std::optional<uint256> assumed_valid_block{};
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
+    const fs::path& blocks_dir;
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -36,8 +36,6 @@ struct ChainstateManagerOpts {
     std::optional<uint256> assumed_valid_block{};
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
-    const fs::path& blocks_dir;
-    const bool fast_prune;
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -37,6 +37,7 @@ struct ChainstateManagerOpts {
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
     const fs::path& blocks_dir;
+    const bool fast_prune;
 };
 
 } // namespace kernel

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2173,7 +2173,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // Fast-path: in this case it is possible to serve the block directly from disk,
         // as the network format matches the format on disk
         std::vector<uint8_t> block_data;
-        if (!ReadRawBlockFromDisk(m_chainman.BlocksDirPath(), block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
+        if (!ReadRawBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
             assert(!"cannot load block from disk");
         }
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BLOCK, Span{block_data}));
@@ -2181,7 +2181,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     } else {
         // Send block from disk
         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-        if (!ReadBlockFromDisk(m_chainman.BlocksDirPath(), *pblockRead, pindex, m_chainparams.GetConsensus())) {
+        if (!ReadBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), *pblockRead, pindex, m_chainparams.GetConsensus())) {
             assert(!"cannot load block from disk");
         }
         pblock = pblockRead;
@@ -3869,7 +3869,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
             if (pindex->nHeight >= m_chainman.ActiveChain().Height() - MAX_BLOCKTXN_DEPTH) {
                 CBlock block;
-                bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), block, pindex, m_chainparams.GetConsensus());
+                bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), block, pindex, m_chainparams.GetConsensus());
                 assert(ret);
 
                 SendBlockTransactions(pfrom, *peer, block, req);
@@ -5524,7 +5524,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         m_connman.PushMessage(pto, std::move(cached_cmpctblock_msg.value()));
                     } else {
                         CBlock block;
-                        bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), block, pBestIndex, consensusParams);
+                        bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), block, pBestIndex, consensusParams);
                         assert(ret);
                         CBlockHeaderAndShortTxIDs cmpctblock{block};
                         m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::CMPCTBLOCK, cmpctblock));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -51,9 +51,6 @@
 #include <optional>
 #include <typeinfo>
 
-using node::ReadBlockFromDisk;
-using node::ReadRawBlockFromDisk;
-
 /** How long to cache transactions in mapRelay for normal relay */
 static constexpr auto RELAY_TX_CACHE_TIME = 15min;
 /** How long a transaction has to be in the mempool before it can unconditionally be relayed (even when not in mapRelay). */
@@ -2173,7 +2170,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // Fast-path: in this case it is possible to serve the block directly from disk,
         // as the network format matches the format on disk
         std::vector<uint8_t> block_data;
-        if (!ReadRawBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
+        if (!m_chainman.m_blockman.ReadRawBlockFromDisk(block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
             assert(!"cannot load block from disk");
         }
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BLOCK, Span{block_data}));
@@ -2181,7 +2178,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     } else {
         // Send block from disk
         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-        if (!ReadBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), *pblockRead, pindex, m_chainparams.GetConsensus())) {
+        if (!m_chainman.m_blockman.ReadBlockFromDisk(*pblockRead, pindex, m_chainparams.GetConsensus())) {
             assert(!"cannot load block from disk");
         }
         pblock = pblockRead;
@@ -3869,7 +3866,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
             if (pindex->nHeight >= m_chainman.ActiveChain().Height() - MAX_BLOCKTXN_DEPTH) {
                 CBlock block;
-                bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), block, pindex, m_chainparams.GetConsensus());
+                bool ret = m_chainman.m_blockman.ReadBlockFromDisk(block, pindex, m_chainparams.GetConsensus());
                 assert(ret);
 
                 SendBlockTransactions(pfrom, *peer, block, req);
@@ -5524,7 +5521,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         m_connman.PushMessage(pto, std::move(cached_cmpctblock_msg.value()));
                     } else {
                         CBlock block;
-                        bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), m_chainman.FastPrune(), block, pBestIndex, consensusParams);
+                        bool ret = m_chainman.m_blockman.ReadBlockFromDisk(block, pBestIndex, consensusParams);
                         assert(ret);
                         CBlockHeaderAndShortTxIDs cmpctblock{block};
                         m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::CMPCTBLOCK, cmpctblock));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2173,7 +2173,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // Fast-path: in this case it is possible to serve the block directly from disk,
         // as the network format matches the format on disk
         std::vector<uint8_t> block_data;
-        if (!ReadRawBlockFromDisk(block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
+        if (!ReadRawBlockFromDisk(m_chainman.BlocksDirPath(), block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
             assert(!"cannot load block from disk");
         }
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BLOCK, Span{block_data}));
@@ -2181,7 +2181,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
     } else {
         // Send block from disk
         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-        if (!ReadBlockFromDisk(*pblockRead, pindex, m_chainparams.GetConsensus())) {
+        if (!ReadBlockFromDisk(m_chainman.BlocksDirPath(), *pblockRead, pindex, m_chainparams.GetConsensus())) {
             assert(!"cannot load block from disk");
         }
         pblock = pblockRead;
@@ -3869,7 +3869,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
             if (pindex->nHeight >= m_chainman.ActiveChain().Height() - MAX_BLOCKTXN_DEPTH) {
                 CBlock block;
-                bool ret = ReadBlockFromDisk(block, pindex, m_chainparams.GetConsensus());
+                bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), block, pindex, m_chainparams.GetConsensus());
                 assert(ret);
 
                 SendBlockTransactions(pfrom, *peer, block, req);
@@ -5524,7 +5524,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         m_connman.PushMessage(pto, std::move(cached_cmpctblock_msg.value()));
                     } else {
                         CBlock block;
-                        bool ret = ReadBlockFromDisk(block, pBestIndex, consensusParams);
+                        bool ret = ReadBlockFromDisk(m_chainman.BlocksDirPath(), block, pBestIndex, consensusParams);
                         assert(ret);
                         CBlockHeaderAndShortTxIDs cmpctblock{block};
                         m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::CMPCTBLOCK, cmpctblock));

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -54,9 +54,9 @@ bool CBlockIndexHeightOnlyComparator::operator()(const CBlockIndex* pa, const CB
     return pa->nHeight < pb->nHeight;
 }
 
-static FILE* OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false);
-static FlatFileSeq BlockFileSeq();
-static FlatFileSeq UndoFileSeq();
+static FILE* OpenUndoFile(const fs::path& blocks_dir, const FlatFilePos& pos, bool fReadOnly = false);
+static FlatFileSeq BlockFileSeq(const fs::path& blocks_dir);
+static FlatFileSeq UndoFileSeq(const fs::path& blocks_dir);
 
 std::vector<CBlockIndex*> BlockManager::GetAllBlockIndices()
 {
@@ -352,7 +352,7 @@ bool BlockManager::LoadBlockIndexDB(const Consensus::Params& consensus_params)
     }
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++) {
         FlatFilePos pos(*it, 0);
-        if (AutoFile{OpenBlockFile(pos, true)}.IsNull()) {
+        if (AutoFile{OpenBlockFile(m_blocks_dir, pos, true)}.IsNull()) {
             return false;
         }
     }
@@ -407,7 +407,7 @@ const CBlockIndex* BlockManager::GetFirstStoredBlock(const CBlockIndex& start_bl
 // rev files since they'll be rewritten by the reindex anyway.  This ensures that m_blockfile_info
 // is in sync with what's actually on disk by the time we start downloading, so that pruning
 // works correctly.
-void CleanupBlockRevFiles()
+void BlockManager::CleanupBlockRevFiles()
 {
     std::map<std::string, fs::path> mapBlockFiles;
 
@@ -415,8 +415,7 @@ void CleanupBlockRevFiles()
     // Remove the rev files immediately and insert the blk file paths into an
     // ordered map keyed by block file index.
     LogPrintf("Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune\n");
-    const fs::path& blocksdir = gArgs.GetBlocksDirPath();
-    for (fs::directory_iterator it(blocksdir); it != fs::directory_iterator(); it++) {
+    for (fs::directory_iterator it(m_blocks_dir); it != fs::directory_iterator(); it++) {
         const std::string path = fs::PathToString(it->path().filename());
         if (fs::is_regular_file(*it) &&
             path.length() == 12 &&
@@ -451,10 +450,10 @@ CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
     return &m_blockfile_info.at(n);
 }
 
-static bool UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
+static bool UndoWriteToDisk(const fs::path blocks_dir, const CBlockUndo& blockundo, FlatFilePos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    AutoFile fileout{OpenUndoFile(pos)};
+    AutoFile fileout{OpenUndoFile(blocks_dir, pos)};
     if (fileout.IsNull()) {
         return error("%s: OpenUndoFile failed", __func__);
     }
@@ -480,7 +479,7 @@ static bool UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos, const
     return true;
 }
 
-bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex)
+bool UndoReadFromDisk(const fs::path& blocks_dir, CBlockUndo& blockundo, const CBlockIndex* pindex)
 {
     const FlatFilePos pos{WITH_LOCK(::cs_main, return pindex->GetUndoPos())};
 
@@ -489,7 +488,7 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex)
     }
 
     // Open history file to read
-    AutoFile filein{OpenUndoFile(pos, true)};
+    AutoFile filein{OpenUndoFile(blocks_dir, pos, true)};
     if (filein.IsNull()) {
         return error("%s: OpenUndoFile failed", __func__);
     }
@@ -516,7 +515,7 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex)
 void BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
-    if (!UndoFileSeq().Flush(undo_pos_old, finalize)) {
+    if (!UndoFileSeq(m_blocks_dir).Flush(undo_pos_old, finalize)) {
         AbortNode("Flushing undo file to disk failed. This is likely the result of an I/O error.");
     }
 }
@@ -535,7 +534,7 @@ void BlockManager::FlushBlockFile(bool fFinalize, bool finalize_undo)
     assert(static_cast<int>(m_blockfile_info.size()) > m_last_blockfile);
 
     FlatFilePos block_pos_old(m_last_blockfile, m_blockfile_info[m_last_blockfile].nSize);
-    if (!BlockFileSeq().Flush(block_pos_old, fFinalize)) {
+    if (!BlockFileSeq(m_blocks_dir).Flush(block_pos_old, fFinalize)) {
         AbortNode("Flushing block file to disk failed. This is likely the result of an I/O error.");
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,
@@ -554,40 +553,40 @@ uint64_t BlockManager::CalculateCurrentUsage()
     return retval;
 }
 
-void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune)
+void BlockManager::UnlinkPrunedFiles(const std::set<int>& setFilesToPrune)
 {
     for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it) {
         FlatFilePos pos(*it, 0);
-        fs::remove(BlockFileSeq().FileName(pos));
-        fs::remove(UndoFileSeq().FileName(pos));
+        fs::remove(BlockFileSeq(m_blocks_dir).FileName(pos));
+        fs::remove(UndoFileSeq(m_blocks_dir).FileName(pos));
         LogPrint(BCLog::BLOCKSTORE, "Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
     }
 }
 
-static FlatFileSeq BlockFileSeq()
+static FlatFileSeq BlockFileSeq(const fs::path& blocks_dir)
 {
-    return FlatFileSeq(gArgs.GetBlocksDirPath(), "blk", gArgs.GetBoolArg("-fastprune", false) ? 0x4000 /* 16kb */ : BLOCKFILE_CHUNK_SIZE);
+    return FlatFileSeq(blocks_dir, "blk", gArgs.GetBoolArg("-fastprune", false) ? 0x4000 /* 16kb */ : BLOCKFILE_CHUNK_SIZE);
 }
 
-static FlatFileSeq UndoFileSeq()
+static FlatFileSeq UndoFileSeq(const fs::path& blocks_dir)
 {
-    return FlatFileSeq(gArgs.GetBlocksDirPath(), "rev", UNDOFILE_CHUNK_SIZE);
+    return FlatFileSeq(blocks_dir, "rev", UNDOFILE_CHUNK_SIZE);
 }
 
-FILE* OpenBlockFile(const FlatFilePos& pos, bool fReadOnly)
+FILE* OpenBlockFile(const fs::path& blocks_dir, const FlatFilePos& pos, bool fReadOnly)
 {
-    return BlockFileSeq().Open(pos, fReadOnly);
+    return BlockFileSeq(blocks_dir).Open(pos, fReadOnly);
 }
 
 /** Open an undo file (rev?????.dat) */
-static FILE* OpenUndoFile(const FlatFilePos& pos, bool fReadOnly)
+static FILE* OpenUndoFile(const fs::path& blocks_dir, const FlatFilePos& pos, bool fReadOnly)
 {
-    return UndoFileSeq().Open(pos, fReadOnly);
+    return UndoFileSeq(blocks_dir).Open(pos, fReadOnly);
 }
 
-fs::path GetBlockPosFilename(const FlatFilePos& pos)
+fs::path GetBlockPosFilename(const fs::path& blocks_dir, const FlatFilePos& pos)
 {
-    return BlockFileSeq().FileName(pos);
+    return BlockFileSeq(blocks_dir).FileName(pos);
 }
 
 bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, CChain& active_chain, uint64_t nTime, bool fKnown)
@@ -632,7 +631,7 @@ bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigne
 
     if (!fKnown) {
         bool out_of_space;
-        size_t bytes_allocated = BlockFileSeq().Allocate(pos, nAddSize, out_of_space);
+        size_t bytes_allocated = BlockFileSeq(m_blocks_dir).Allocate(pos, nAddSize, out_of_space);
         if (out_of_space) {
             return AbortNode("Disk space is too low!", _("Disk space is too low!"));
         }
@@ -656,7 +655,7 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     m_dirty_fileinfo.insert(nFile);
 
     bool out_of_space;
-    size_t bytes_allocated = UndoFileSeq().Allocate(pos, nAddSize, out_of_space);
+    size_t bytes_allocated = UndoFileSeq(m_blocks_dir).Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
         return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
     }
@@ -667,10 +666,14 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     return true;
 }
 
-static bool WriteBlockToDisk(const CBlock& block, FlatFilePos& pos, const CMessageHeader::MessageStartChars& messageStart)
+fs::path BlockManager::BlocksDirPath() {
+    return m_blocks_dir;
+}
+
+static bool WriteBlockToDisk(const fs::path& blocks_dir, const CBlock& block, FlatFilePos& pos, const CMessageHeader::MessageStartChars& messageStart)
 {
     // Open history file to append
-    CAutoFile fileout(OpenBlockFile(pos), SER_DISK, CLIENT_VERSION);
+    CAutoFile fileout(OpenBlockFile(blocks_dir, pos), SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull()) {
         return error("WriteBlockToDisk: OpenBlockFile failed");
     }
@@ -699,7 +702,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
         if (!FindUndoPos(state, pindex->nFile, _pos, ::GetSerializeSize(blockundo, CLIENT_VERSION) + 40)) {
             return error("ConnectBlock(): FindUndoPos failed");
         }
-        if (!UndoWriteToDisk(blockundo, _pos, pindex->pprev->GetBlockHash(), chainparams.MessageStart())) {
+        if (!UndoWriteToDisk(m_blocks_dir, blockundo, _pos, pindex->pprev->GetBlockHash(), chainparams.MessageStart())) {
             return AbortNode(state, "Failed to write undo data");
         }
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
@@ -720,12 +723,12 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
+bool ReadBlockFromDisk(const fs::path& blocks_dir, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
 {
     block.SetNull();
 
     // Open history file to read
-    CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
+    CAutoFile filein(OpenBlockFile(blocks_dir, pos, true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
         return error("ReadBlockFromDisk: OpenBlockFile failed for %s", pos.ToString());
     }
@@ -750,11 +753,11 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+bool ReadBlockFromDisk(const fs::path& blocks_dir, CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
     const FlatFilePos block_pos{WITH_LOCK(cs_main, return pindex->GetBlockPos())};
 
-    if (!ReadBlockFromDisk(block, block_pos, consensusParams)) {
+    if (!ReadBlockFromDisk(blocks_dir, block, block_pos, consensusParams)) {
         return false;
     }
     if (block.GetHash() != pindex->GetBlockHash()) {
@@ -764,11 +767,11 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
     return true;
 }
 
-bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
+bool ReadRawBlockFromDisk(const fs::path& blocks_dir, std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
 {
     FlatFilePos hpos = pos;
     hpos.nPos -= 8; // Seek back 8 bytes for meta header
-    AutoFile filein{OpenBlockFile(hpos, true)};
+    AutoFile filein{OpenBlockFile(blocks_dir, hpos, true)};
     if (filein.IsNull()) {
         return error("%s: OpenBlockFile failed for %s", __func__, pos.ToString());
     }
@@ -817,7 +820,7 @@ FlatFilePos BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight, CCha
         return FlatFilePos();
     }
     if (!position_known) {
-        if (!WriteBlockToDisk(block, blockPos, chainparams.MessageStart())) {
+        if (!WriteBlockToDisk(m_blocks_dir, block, blockPos, chainparams.MessageStart())) {
             AbortNode("Failed to write block");
             return FlatFilePos();
         }
@@ -855,10 +858,10 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
             std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
             while (true) {
                 FlatFilePos pos(nFile, 0);
-                if (!fs::exists(GetBlockPosFilename(pos))) {
+                if (!fs::exists(GetBlockPosFilename(chainman.m_blockman.BlocksDirPath(), pos))) {
                     break; // No block files left to reindex
                 }
-                FILE* file = OpenBlockFile(pos, true);
+                FILE* file = OpenBlockFile(chainman.m_blockman.BlocksDirPath(), pos, true);
                 if (!file) {
                     break; // This error is logged in OpenBlockFile
                 }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -407,7 +407,7 @@ const CBlockIndex* BlockManager::GetFirstStoredBlock(const CBlockIndex& start_bl
 // rev files since they'll be rewritten by the reindex anyway.  This ensures that m_blockfile_info
 // is in sync with what's actually on disk by the time we start downloading, so that pruning
 // works correctly.
-void BlockManager::CleanupBlockRevFiles()
+void BlockManager::CleanupBlockRevFiles() const
 {
     std::map<std::string, fs::path> mapBlockFiles;
 
@@ -479,7 +479,7 @@ static bool UndoWriteToDisk(const fs::path blocks_dir, const CBlockUndo& blockun
     return true;
 }
 
-bool BlockManager::UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex)
+bool BlockManager::UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex) const
 {
     const FlatFilePos pos{WITH_LOCK(::cs_main, return pindex->GetUndoPos())};
 
@@ -553,7 +553,7 @@ uint64_t BlockManager::CalculateCurrentUsage()
     return retval;
 }
 
-void BlockManager::UnlinkPrunedFiles(const std::set<int>& setFilesToPrune)
+void BlockManager::UnlinkPrunedFiles(const std::set<int>& setFilesToPrune) const
 {
     for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it) {
         FlatFilePos pos(*it, 0);
@@ -573,7 +573,7 @@ static FlatFileSeq UndoFileSeq(const fs::path& blocks_dir)
     return FlatFileSeq(blocks_dir, "rev", UNDOFILE_CHUNK_SIZE);
 }
 
-FILE* BlockManager::OpenBlockFile(const FlatFilePos& pos, bool fReadOnly)
+FILE* BlockManager::OpenBlockFile(const FlatFilePos& pos, bool fReadOnly) const
 {
     return ::node::OpenBlockFile(m_options.blocks_dir, m_options.fast_prune, pos, fReadOnly);
 }
@@ -589,7 +589,7 @@ static FILE* OpenUndoFile(const fs::path& blocks_dir, const FlatFilePos& pos, bo
     return UndoFileSeq(blocks_dir).Open(pos, fReadOnly);
 }
 
-fs::path BlockManager::GetBlockPosFilename(const FlatFilePos& pos)
+fs::path BlockManager::GetBlockPosFilename(const FlatFilePos& pos) const
 {
     return BlockFileSeq(m_options.blocks_dir, m_options.fast_prune).FileName(pos);
 }
@@ -724,12 +724,12 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     return true;
 }
 
-bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams) const
 {
     return ::node::ReadBlockFromDisk(m_options.blocks_dir, m_options.fast_prune, block, pindex, consensusParams);
 }
 
-bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
+bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams) const
 {
     return ::node::ReadBlockFromDisk(m_options.blocks_dir, m_options.fast_prune, block, pos, consensusParams);
 }
@@ -778,7 +778,7 @@ bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock
     return true;
 }
 
-bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
+bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start) const
 {
     FlatFilePos hpos = pos;
     hpos.nPos -= 8; // Seek back 8 bytes for meta header

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -479,7 +479,7 @@ static bool UndoWriteToDisk(const fs::path blocks_dir, const CBlockUndo& blockun
     return true;
 }
 
-bool UndoReadFromDisk(const fs::path& blocks_dir, CBlockUndo& blockundo, const CBlockIndex* pindex)
+bool BlockManager::UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex)
 {
     const FlatFilePos pos{WITH_LOCK(::cs_main, return pindex->GetUndoPos())};
 
@@ -488,7 +488,7 @@ bool UndoReadFromDisk(const fs::path& blocks_dir, CBlockUndo& blockundo, const C
     }
 
     // Open history file to read
-    AutoFile filein{OpenUndoFile(blocks_dir, pos, true)};
+    AutoFile filein{OpenUndoFile(m_blocks_dir, pos, true)};
     if (filein.IsNull()) {
         return error("%s: OpenUndoFile failed", __func__);
     }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -727,6 +727,16 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     return true;
 }
 
+bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+{
+    return ::node::ReadBlockFromDisk(m_blocks_dir, m_fast_prune, block, pindex, consensusParams);
+}
+
+bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
+{
+    return ::node::ReadBlockFromDisk(m_blocks_dir, m_fast_prune, block, pos, consensusParams);
+}
+
 bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
 {
     block.SetNull();
@@ -771,11 +781,11 @@ bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock
     return true;
 }
 
-bool ReadRawBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
+bool BlockManager::ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
 {
     FlatFilePos hpos = pos;
     hpos.nPos -= 8; // Seek back 8 bytes for meta header
-    AutoFile filein{OpenBlockFile(blocks_dir, fast_prune, hpos, true)};
+    AutoFile filein{OpenBlockFile(m_blocks_dir, m_fast_prune, hpos, true)};
     if (filein.IsNull()) {
         return error("%s: OpenBlockFile failed for %s", __func__, pos.ToString());
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -139,10 +139,12 @@ private:
     std::unordered_map<std::string, PruneLockInfo> m_prune_locks GUARDED_BY(::cs_main);
 
     const fs::path& m_blocks_dir;
+    const bool m_fast_prune;
 
 public:
-    BlockManager(const fs::path& blocks_dir)
-        : m_blocks_dir(blocks_dir){};
+    BlockManager(const fs::path& blocks_dir, const bool fast_prune)
+        : m_blocks_dir(blocks_dir),
+        m_fast_prune(fast_prune){};
 
     BlockMap m_block_index GUARDED_BY(cs_main);
 
@@ -214,18 +216,19 @@ public:
      */
     void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
-    fs::path BlocksDirPath();
+    const fs::path& BlocksDirPath();
+    bool FastPrune();
 };
 
 /** Open a block file (blk?????.dat) */
-FILE* OpenBlockFile(const fs::path& blocks_dir, const FlatFilePos& pos, bool fReadOnly = false);
+FILE* OpenBlockFile(const fs::path& blocks_dir, const bool fast_prune, const FlatFilePos& pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
 fs::path GetBlockPosFilename(const fs::path& blocks_dir, const FlatFilePos& pos);
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(const fs::path& blocks_dir, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
-bool ReadBlockFromDisk(const fs::path& blocks_dir, CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
-bool ReadRawBlockFromDisk(const fs::path& blocks_dir, std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
+bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+bool ReadRawBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 
 bool UndoReadFromDisk(const fs::path& blocks_dir, CBlockUndo& blockundo, const CBlockIndex* pindex);
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -218,6 +218,9 @@ public:
 
     /** Functions for disk access for blocks */
     bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
+    bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
+    bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+    bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 
     const fs::path& BlocksDirPath();
     bool FastPrune();
@@ -231,7 +234,6 @@ fs::path GetBlockPosFilename(const fs::path& blocks_dir, const FlatFilePos& pos)
 /** Functions for disk access for blocks */
 bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
-bool ReadRawBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 
 void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFiles, const ArgsManager& args, const fs::path& mempool_path);
 } // namespace node

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -9,6 +9,7 @@
 #include <chain.h>
 #include <fs.h>
 #include <kernel/cs_main.h>
+#include <kernel/blockmanager_opts.h>
 #include <protocol.h>
 #include <sync.h>
 #include <txdb.h>
@@ -34,7 +35,6 @@ struct Params;
 }
 
 namespace node {
-static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
 
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
@@ -138,13 +138,13 @@ private:
      */
     std::unordered_map<std::string, PruneLockInfo> m_prune_locks GUARDED_BY(::cs_main);
 
-    const fs::path& m_blocks_dir;
-    const bool m_fast_prune;
-
 public:
-    BlockManager(const fs::path& blocks_dir, const bool fast_prune)
-        : m_blocks_dir(blocks_dir),
-        m_fast_prune(fast_prune){};
+    using Options = kernel::BlockManagerOpts;
+
+    BlockManager(const Options options)
+        : m_options(options){};
+
+    const Options m_options;
 
     BlockMap m_block_index GUARDED_BY(cs_main);
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -209,22 +209,22 @@ public:
     //! Create or update a prune lock identified by its name
     void UpdatePruneLock(const std::string& name, const PruneLockInfo& lock_info) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    void CleanupBlockRevFiles();
+    void CleanupBlockRevFiles() const;
 
     /**
      *  Actually unlink the specified files
      */
-    void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
+    void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune) const;
 
     /** Translation to a filesystem path */
-    fs::path GetBlockPosFilename(const FlatFilePos& pos);
+    fs::path GetBlockPosFilename(const FlatFilePos& pos) const;
 
     /** Functions for disk access for blocks */
-    bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
-    bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
-    bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
-    bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
-    FILE* OpenBlockFile(const FlatFilePos& pos, bool fReadOnly);
+    bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex) const;
+    bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams) const;
+    bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams) const;
+    bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start) const;
+    FILE* OpenBlockFile(const FlatFilePos& pos, bool fReadOnly) const;
 };
 
 /** Open a block file (blk?????.dat) */

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -216,6 +216,9 @@ public:
      */
     void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
+    /** Functions for disk access for blocks */
+    bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
+
     const fs::path& BlocksDirPath();
     bool FastPrune();
 };
@@ -229,8 +232,6 @@ fs::path GetBlockPosFilename(const fs::path& blocks_dir, const FlatFilePos& pos)
 bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 bool ReadRawBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
-
-bool UndoReadFromDisk(const fs::path& blocks_dir, CBlockUndo& blockundo, const CBlockIndex* pindex);
 
 void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFiles, const ArgsManager& args, const fs::path& mempool_path);
 } // namespace node

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -216,20 +216,19 @@ public:
      */
     void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
+    /** Translation to a filesystem path */
+    fs::path GetBlockPosFilename(const FlatFilePos& pos);
+
     /** Functions for disk access for blocks */
     bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
     bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
     bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
     bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
-
-    const fs::path& BlocksDirPath();
-    bool FastPrune();
+    FILE* OpenBlockFile(const FlatFilePos& pos, bool fReadOnly);
 };
 
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const fs::path& blocks_dir, const bool fast_prune, const FlatFilePos& pos, bool fReadOnly = false);
-/** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const fs::path& blocks_dir, const FlatFilePos& pos);
 
 /** Functions for disk access for blocks */
 bool ReadBlockFromDisk(const fs::path& blocks_dir, const bool fast_prune, CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -70,7 +70,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         pblocktree->WriteReindexing(true);
         //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
         if (options.prune) {
-            CleanupBlockRevFiles();
+            chainman.m_blockman.CleanupBlockRevFiles();
         }
     }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -392,7 +392,7 @@ public:
     NodeContext* m_context{nullptr};
 };
 
-bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active)
+bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const fs::path& blocks_dir)
 {
     if (!index) return false;
     if (block.m_hash) *block.m_hash = index->GetBlockHash();
@@ -402,10 +402,10 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_mtp_time) *block.m_mtp_time = index->GetMedianTimePast();
     if (block.m_in_active_chain) *block.m_in_active_chain = active[index->nHeight] == index;
     if (block.m_locator) { *block.m_locator = GetLocator(index); }
-    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active);
+    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blocks_dir);
     if (block.m_data) {
         REVERSE_LOCK(lock);
-        if (!ReadBlockFromDisk(*block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
+        if (!ReadBlockFromDisk(blocks_dir, *block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
     }
     block.found = true;
     return true;
@@ -555,13 +555,13 @@ public:
     bool findBlock(const uint256& hash, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
-        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain());
+        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().BlocksDirPath());
     }
     bool findFirstBlockWithTimeAndHeight(int64_t min_time, int min_height, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
         const CChain& active = chainman().ActiveChain();
-        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active);
+        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, chainman().BlocksDirPath());
     }
     bool findAncestorByHeight(const uint256& block_hash, int ancestor_height, const FoundBlock& ancestor_out) override
     {
@@ -569,10 +569,10 @@ public:
         const CChain& active = chainman().ActiveChain();
         if (const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash)) {
             if (const CBlockIndex* ancestor = block->GetAncestor(ancestor_height)) {
-                return FillBlock(ancestor, ancestor_out, lock, active);
+                return FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath());
             }
         }
-        return FillBlock(nullptr, ancestor_out, lock, active);
+        return FillBlock(nullptr, ancestor_out, lock, active, chainman().BlocksDirPath());
     }
     bool findAncestorByHash(const uint256& block_hash, const uint256& ancestor_hash, const FoundBlock& ancestor_out) override
     {
@@ -580,7 +580,7 @@ public:
         const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash);
         const CBlockIndex* ancestor = chainman().m_blockman.LookupBlockIndex(ancestor_hash);
         if (block && ancestor && block->GetAncestor(ancestor->nHeight) != ancestor) ancestor = nullptr;
-        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain());
+        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), chainman().BlocksDirPath());
     }
     bool findCommonAncestor(const uint256& block_hash1, const uint256& block_hash2, const FoundBlock& ancestor_out, const FoundBlock& block1_out, const FoundBlock& block2_out) override
     {
@@ -592,9 +592,9 @@ public:
         // Using & instead of && below to avoid short circuiting and leaving
         // output uninitialized. Cast bool to int to avoid -Wbitwise-instead-of-logical
         // compiler warnings.
-        return int{FillBlock(ancestor, ancestor_out, lock, active)} &
-               int{FillBlock(block1, block1_out, lock, active)} &
-               int{FillBlock(block2, block2_out, lock, active)};
+        return int{FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath())} &
+               int{FillBlock(block1, block1_out, lock, active, chainman().BlocksDirPath())} &
+               int{FillBlock(block2, block2_out, lock, active, chainman().BlocksDirPath())};
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -392,7 +392,7 @@ public:
     NodeContext* m_context{nullptr};
 };
 
-bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, BlockManager& blockman)
+bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const BlockManager& blockman)
 {
     if (!index) return false;
     if (block.m_hash) *block.m_hash = index->GetBlockHash();

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -392,7 +392,7 @@ public:
     NodeContext* m_context{nullptr};
 };
 
-bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const fs::path& blocks_dir)
+bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const fs::path& blocks_dir, const bool fast_prune)
 {
     if (!index) return false;
     if (block.m_hash) *block.m_hash = index->GetBlockHash();
@@ -402,10 +402,10 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_mtp_time) *block.m_mtp_time = index->GetMedianTimePast();
     if (block.m_in_active_chain) *block.m_in_active_chain = active[index->nHeight] == index;
     if (block.m_locator) { *block.m_locator = GetLocator(index); }
-    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blocks_dir);
+    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blocks_dir, fast_prune);
     if (block.m_data) {
         REVERSE_LOCK(lock);
-        if (!ReadBlockFromDisk(blocks_dir, *block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
+        if (!ReadBlockFromDisk(blocks_dir, fast_prune, *block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
     }
     block.found = true;
     return true;
@@ -555,13 +555,13 @@ public:
     bool findBlock(const uint256& hash, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
-        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().BlocksDirPath());
+        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().BlocksDirPath(), chainman().FastPrune());
     }
     bool findFirstBlockWithTimeAndHeight(int64_t min_time, int min_height, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
         const CChain& active = chainman().ActiveChain();
-        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, chainman().BlocksDirPath());
+        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, chainman().BlocksDirPath(), chainman().FastPrune());
     }
     bool findAncestorByHeight(const uint256& block_hash, int ancestor_height, const FoundBlock& ancestor_out) override
     {
@@ -569,10 +569,10 @@ public:
         const CChain& active = chainman().ActiveChain();
         if (const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash)) {
             if (const CBlockIndex* ancestor = block->GetAncestor(ancestor_height)) {
-                return FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath());
+                return FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune());
             }
         }
-        return FillBlock(nullptr, ancestor_out, lock, active, chainman().BlocksDirPath());
+        return FillBlock(nullptr, ancestor_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune());
     }
     bool findAncestorByHash(const uint256& block_hash, const uint256& ancestor_hash, const FoundBlock& ancestor_out) override
     {
@@ -580,7 +580,7 @@ public:
         const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash);
         const CBlockIndex* ancestor = chainman().m_blockman.LookupBlockIndex(ancestor_hash);
         if (block && ancestor && block->GetAncestor(ancestor->nHeight) != ancestor) ancestor = nullptr;
-        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), chainman().BlocksDirPath());
+        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), chainman().BlocksDirPath(), chainman().FastPrune());
     }
     bool findCommonAncestor(const uint256& block_hash1, const uint256& block_hash2, const FoundBlock& ancestor_out, const FoundBlock& block1_out, const FoundBlock& block2_out) override
     {
@@ -592,9 +592,9 @@ public:
         // Using & instead of && below to avoid short circuiting and leaving
         // output uninitialized. Cast bool to int to avoid -Wbitwise-instead-of-logical
         // compiler warnings.
-        return int{FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath())} &
-               int{FillBlock(block1, block1_out, lock, active, chainman().BlocksDirPath())} &
-               int{FillBlock(block2, block2_out, lock, active, chainman().BlocksDirPath())};
+        return int{FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune())} &
+               int{FillBlock(block1, block1_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune())} &
+               int{FillBlock(block2, block2_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune())};
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -392,7 +392,7 @@ public:
     NodeContext* m_context{nullptr};
 };
 
-bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, const fs::path& blocks_dir, const bool fast_prune)
+bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<RecursiveMutex>& lock, const CChain& active, BlockManager& blockman)
 {
     if (!index) return false;
     if (block.m_hash) *block.m_hash = index->GetBlockHash();
@@ -402,10 +402,10 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_mtp_time) *block.m_mtp_time = index->GetMedianTimePast();
     if (block.m_in_active_chain) *block.m_in_active_chain = active[index->nHeight] == index;
     if (block.m_locator) { *block.m_locator = GetLocator(index); }
-    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blocks_dir, fast_prune);
+    if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blockman);
     if (block.m_data) {
         REVERSE_LOCK(lock);
-        if (!ReadBlockFromDisk(blocks_dir, fast_prune, *block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
+        if (!ReadBlockFromDisk(blockman.BlocksDirPath(), blockman.FastPrune(), *block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
     }
     block.found = true;
     return true;
@@ -555,13 +555,13 @@ public:
     bool findBlock(const uint256& hash, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
-        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().BlocksDirPath(), chainman().FastPrune());
+        return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().m_blockman);
     }
     bool findFirstBlockWithTimeAndHeight(int64_t min_time, int min_height, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);
         const CChain& active = chainman().ActiveChain();
-        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, chainman().BlocksDirPath(), chainman().FastPrune());
+        return FillBlock(active.FindEarliestAtLeast(min_time, min_height), block, lock, active, chainman().m_blockman);
     }
     bool findAncestorByHeight(const uint256& block_hash, int ancestor_height, const FoundBlock& ancestor_out) override
     {
@@ -569,10 +569,10 @@ public:
         const CChain& active = chainman().ActiveChain();
         if (const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash)) {
             if (const CBlockIndex* ancestor = block->GetAncestor(ancestor_height)) {
-                return FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune());
+                return FillBlock(ancestor, ancestor_out, lock, active, chainman().m_blockman);
             }
         }
-        return FillBlock(nullptr, ancestor_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune());
+        return FillBlock(nullptr, ancestor_out, lock, active, chainman().m_blockman);
     }
     bool findAncestorByHash(const uint256& block_hash, const uint256& ancestor_hash, const FoundBlock& ancestor_out) override
     {
@@ -580,7 +580,7 @@ public:
         const CBlockIndex* block = chainman().m_blockman.LookupBlockIndex(block_hash);
         const CBlockIndex* ancestor = chainman().m_blockman.LookupBlockIndex(ancestor_hash);
         if (block && ancestor && block->GetAncestor(ancestor->nHeight) != ancestor) ancestor = nullptr;
-        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), chainman().BlocksDirPath(), chainman().FastPrune());
+        return FillBlock(ancestor, ancestor_out, lock, chainman().ActiveChain(), chainman().m_blockman);
     }
     bool findCommonAncestor(const uint256& block_hash1, const uint256& block_hash2, const FoundBlock& ancestor_out, const FoundBlock& block1_out, const FoundBlock& block2_out) override
     {
@@ -592,9 +592,9 @@ public:
         // Using & instead of && below to avoid short circuiting and leaving
         // output uninitialized. Cast bool to int to avoid -Wbitwise-instead-of-logical
         // compiler warnings.
-        return int{FillBlock(ancestor, ancestor_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune())} &
-               int{FillBlock(block1, block1_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune())} &
-               int{FillBlock(block2, block2_out, lock, active, chainman().BlocksDirPath(), chainman().FastPrune())};
+        return int{FillBlock(ancestor, ancestor_out, lock, active, chainman().m_blockman)} &
+               int{FillBlock(block1, block1_out, lock, active, chainman().m_blockman)} &
+               int{FillBlock(block2, block2_out, lock, active, chainman().m_blockman)};
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -405,7 +405,7 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active, blockman);
     if (block.m_data) {
         REVERSE_LOCK(lock);
-        if (!ReadBlockFromDisk(blockman.BlocksDirPath(), blockman.FastPrune(), *block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
+        if (!blockman.ReadBlockFromDisk(*block.m_data, index, Params().GetConsensus())) block.m_data->SetNull();
     }
     block.found = true;
     return true;

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -122,7 +122,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
@@ -143,7 +143,7 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     if (block_index) {
         CBlock block;
-        if (ReadBlockFromDisk(block, block_index, consensusParams)) {
+        if (ReadBlockFromDisk(blocks_dir, block, block_index, consensusParams)) {
             for (const auto& tx : block.vtx) {
                 if (tx->GetHash() == hash) {
                     hashBlock = block_index->GetBlockHash();

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -122,7 +122,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir, const bool fast_prune)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
@@ -143,7 +143,7 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     if (block_index) {
         CBlock block;
-        if (ReadBlockFromDisk(blocks_dir, block, block_index, consensusParams)) {
+        if (ReadBlockFromDisk(blocks_dir, fast_prune, block, block_index, consensusParams)) {
             for (const auto& tx : block.vtx) {
                 if (tx->GetHash() == hash) {
                     hashBlock = block_index->GetBlockHash();

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -122,7 +122,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir, const bool fast_prune)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, BlockManager& blockman)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);
@@ -143,7 +143,7 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     if (block_index) {
         CBlock block;
-        if (ReadBlockFromDisk(blocks_dir, fast_prune, block, block_index, consensusParams)) {
+        if (blockman.ReadBlockFromDisk(block, block_index, consensusParams)) {
             for (const auto& tx : block.vtx) {
                 if (tx->GetHash() == hash) {
                     hashBlock = block_index->GetBlockHash();

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -122,7 +122,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     return TransactionError::OK;
 }
 
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, BlockManager& blockman)
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const BlockManager& blockman)
 {
     if (mempool && !block_index) {
         CTransactionRef ptx = mempool->get(hash);

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -8,6 +8,7 @@
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <util/error.h>
+#include <fs.h>
 
 class CBlockIndex;
 class CTxMemPool;
@@ -57,7 +58,7 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -59,7 +59,7 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, BlockManager& blockman);
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const BlockManager& blockman);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -58,7 +58,7 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir);
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir, const bool fast_prune);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_NODE_TRANSACTION_H
 #define BITCOIN_NODE_TRANSACTION_H
 
+#include <node/blockstorage.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <util/error.h>
@@ -58,7 +59,7 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[out] hashBlock       The block hash, if the tx was found via -txindex or block_index
  * @returns                    The tx if found, otherwise nullptr
  */
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, const fs::path& blocks_dir, const bool fast_prune);
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock, BlockManager& blockman);
 } // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -307,7 +307,7 @@ static bool rest_block(const std::any& context,
 
     }
 
-    if (!ReadBlockFromDisk(chainman.BlocksDirPath(), block, pblockindex, chainman.GetParams().GetConsensus())) {
+    if (!ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, pblockindex, chainman.GetParams().GetConsensus())) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }
 
@@ -685,7 +685,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     const NodeContext* const node = GetNodeContext(context, req);
     if (!node) return false;
     uint256 hashBlock = uint256();
-    const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, node->mempool.get(), hash, Params().GetConsensus(), hashBlock, node->chainman->BlocksDirPath());
+    const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, node->mempool.get(), hash, Params().GetConsensus(), hashBlock, node->chainman->BlocksDirPath(), node->chainman->FastPrune());
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -307,7 +307,7 @@ static bool rest_block(const std::any& context,
 
     }
 
-    if (!ReadBlockFromDisk(block, pblockindex, chainman.GetParams().GetConsensus())) {
+    if (!ReadBlockFromDisk(chainman.BlocksDirPath(), block, pblockindex, chainman.GetParams().GetConsensus())) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }
 
@@ -685,7 +685,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     const NodeContext* const node = GetNodeContext(context, req);
     if (!node) return false;
     uint256 hashBlock = uint256();
-    const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, node->mempool.get(), hash, Params().GetConsensus(), hashBlock);
+    const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, node->mempool.get(), hash, Params().GetConsensus(), hashBlock, node->chainman->BlocksDirPath());
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -36,7 +36,6 @@
 
 using node::GetTransaction;
 using node::NodeContext;
-using node::ReadBlockFromDisk;
 
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;
@@ -307,7 +306,7 @@ static bool rest_block(const std::any& context,
 
     }
 
-    if (!ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, pblockindex, chainman.GetParams().GetConsensus())) {
+    if (!chainman.m_blockman.ReadBlockFromDisk(block, pblockindex, chainman.GetParams().GetConsensus())) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }
 
@@ -685,7 +684,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     const NodeContext* const node = GetNodeContext(context, req);
     if (!node) return false;
     uint256 hashBlock = uint256();
-    const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, node->mempool.get(), hash, Params().GetConsensus(), hashBlock, node->chainman->BlocksDirPath(), node->chainman->FastPrune());
+    const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, node->mempool.get(), hash, Params().GetConsensus(), hashBlock, node->chainman->m_blockman);
     if (!tx) {
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -58,7 +58,6 @@ using kernel::CoinStatsHashType;
 
 using node::BlockManager;
 using node::NodeContext;
-using node::ReadBlockFromDisk;
 using node::SnapshotMetadata;
 
 struct CUpdatedBlock
@@ -585,7 +584,7 @@ static CBlock GetBlockChecked(BlockManager& blockman, const CBlockIndex* pblocki
         }
     }
 
-    if (!ReadBlockFromDisk(blockman.BlocksDirPath(), blockman.FastPrune(), block, pblockindex, Params().GetConsensus())) {
+    if (!blockman.ReadBlockFromDisk(block, pblockindex, Params().GetConsensus())) {
         // Block not found on disk. This could be because we have the block
         // header in our index but not yet have the block or did not accept the
         // block. Or if the block was pruned right after we released the lock above.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -60,7 +60,6 @@ using node::BlockManager;
 using node::NodeContext;
 using node::ReadBlockFromDisk;
 using node::SnapshotMetadata;
-using node::UndoReadFromDisk;
 
 struct CUpdatedBlock
 {
@@ -183,7 +182,7 @@ UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIn
         case TxVerbosity::SHOW_DETAILS_AND_PREVOUT:
             CBlockUndo blockUndo;
             const bool is_not_pruned{WITH_LOCK(::cs_main, return !blockman.IsBlockPruned(blockindex))};
-            const bool have_undo{is_not_pruned && UndoReadFromDisk(blockman.BlocksDirPath(), blockUndo, blockindex)};
+            const bool have_undo{is_not_pruned && blockman.UndoReadFromDisk(blockUndo, blockindex)};
 
             for (size_t i = 0; i < block.vtx.size(); ++i) {
                 const CTransactionRef& tx = block.vtx.at(i);
@@ -610,7 +609,7 @@ static CBlockUndo GetUndoChecked(BlockManager& blockman, const CBlockIndex* pblo
         }
     }
 
-    if (!UndoReadFromDisk(blockman.BlocksDirPath(), blockUndo, pblockindex)) {
+    if (!blockman.UndoReadFromDisk(blockUndo, pblockindex)) {
         throw JSONRPCError(RPC_MISC_ERROR, "Can't read undo data from disk");
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -183,7 +183,7 @@ UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIn
         case TxVerbosity::SHOW_DETAILS_AND_PREVOUT:
             CBlockUndo blockUndo;
             const bool is_not_pruned{WITH_LOCK(::cs_main, return !blockman.IsBlockPruned(blockindex))};
-            const bool have_undo{is_not_pruned && UndoReadFromDisk(blockUndo, blockindex)};
+            const bool have_undo{is_not_pruned && UndoReadFromDisk(blockman.BlocksDirPath(), blockUndo, blockindex)};
 
             for (size_t i = 0; i < block.vtx.size(); ++i) {
                 const CTransactionRef& tx = block.vtx.at(i);
@@ -586,7 +586,7 @@ static CBlock GetBlockChecked(BlockManager& blockman, const CBlockIndex* pblocki
         }
     }
 
-    if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(blockman.BlocksDirPath(), block, pblockindex, Params().GetConsensus())) {
         // Block not found on disk. This could be because we have the block
         // header in our index but not yet have the block or did not accept the
         // block. Or if the block was pruned right after we released the lock above.
@@ -610,7 +610,7 @@ static CBlockUndo GetUndoChecked(BlockManager& blockman, const CBlockIndex* pblo
         }
     }
 
-    if (!UndoReadFromDisk(blockUndo, pblockindex)) {
+    if (!UndoReadFromDisk(blockman.BlocksDirPath(), blockUndo, pblockindex)) {
         throw JSONRPCError(RPC_MISC_ERROR, "Can't read undo data from disk");
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -586,7 +586,7 @@ static CBlock GetBlockChecked(BlockManager& blockman, const CBlockIndex* pblocki
         }
     }
 
-    if (!ReadBlockFromDisk(blockman.BlocksDirPath(), block, pblockindex, Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(blockman.BlocksDirPath(), blockman.FastPrune(), block, pblockindex, Params().GetConsensus())) {
         // Block not found on disk. This could be because we have the block
         // header in our index but not yet have the block or did not accept the
         // block. Or if the block was pruned right after we released the lock above.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -52,7 +52,6 @@ using node::GetTransaction;
 using node::NodeContext;
 using node::PSBTAnalysis;
 using node::ReadBlockFromDisk;
-using node::UndoReadFromDisk;
 
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry,
                      Chainstate& active_chainstate, const CTxUndo* txundo = nullptr,
@@ -321,7 +320,7 @@ static RPCHelpMan getrawtransaction()
 
     if (tx->IsCoinBase() ||
         !blockindex || is_block_pruned ||
-        !(UndoReadFromDisk(chainman.BlocksDirPath(), blockUndo, blockindex) && ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, blockindex, Params().GetConsensus()))) {
+        !(chainman.m_blockman.UndoReadFromDisk(blockUndo, blockindex) && ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, blockindex, Params().GetConsensus()))) {
         TxToJSON(*tx, hash_block, result, chainman.ActiveChainstate());
         return result;
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -277,7 +277,7 @@ static RPCHelpMan getrawtransaction()
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), hash, chainman.GetConsensus(), hash_block, chainman.BlocksDirPath());
+    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), hash, chainman.GetConsensus(), hash_block, chainman.BlocksDirPath(), chainman.FastPrune());
     if (!tx) {
         std::string errmsg;
         if (blockindex) {
@@ -321,7 +321,7 @@ static RPCHelpMan getrawtransaction()
 
     if (tx->IsCoinBase() ||
         !blockindex || is_block_pruned ||
-        !(UndoReadFromDisk(chainman.BlocksDirPath(), blockUndo, blockindex) && ReadBlockFromDisk(chainman.BlocksDirPath(), block, blockindex, Params().GetConsensus()))) {
+        !(UndoReadFromDisk(chainman.BlocksDirPath(), blockUndo, blockindex) && ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, blockindex, Params().GetConsensus()))) {
         TxToJSON(*tx, hash_block, result, chainman.ActiveChainstate());
         return result;
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -51,7 +51,6 @@ using node::FindCoins;
 using node::GetTransaction;
 using node::NodeContext;
 using node::PSBTAnalysis;
-using node::ReadBlockFromDisk;
 
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry,
                      Chainstate& active_chainstate, const CTxUndo* txundo = nullptr,
@@ -276,7 +275,7 @@ static RPCHelpMan getrawtransaction()
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), hash, chainman.GetConsensus(), hash_block, chainman.BlocksDirPath(), chainman.FastPrune());
+    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), hash, chainman.GetConsensus(), hash_block, chainman.m_blockman);
     if (!tx) {
         std::string errmsg;
         if (blockindex) {
@@ -320,7 +319,7 @@ static RPCHelpMan getrawtransaction()
 
     if (tx->IsCoinBase() ||
         !blockindex || is_block_pruned ||
-        !(chainman.m_blockman.UndoReadFromDisk(blockUndo, blockindex) && ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, blockindex, Params().GetConsensus()))) {
+        !(chainman.m_blockman.UndoReadFromDisk(blockUndo, blockindex) && chainman.m_blockman.ReadBlockFromDisk(block, blockindex, Params().GetConsensus()))) {
         TxToJSON(*tx, hash_block, result, chainman.ActiveChainstate());
         return result;
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -277,7 +277,7 @@ static RPCHelpMan getrawtransaction()
     }
 
     uint256 hash_block;
-    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), hash, chainman.GetConsensus(), hash_block);
+    const CTransactionRef tx = GetTransaction(blockindex, node.mempool.get(), hash, chainman.GetConsensus(), hash_block, chainman.BlocksDirPath());
     if (!tx) {
         std::string errmsg;
         if (blockindex) {
@@ -321,7 +321,7 @@ static RPCHelpMan getrawtransaction()
 
     if (tx->IsCoinBase() ||
         !blockindex || is_block_pruned ||
-        !(UndoReadFromDisk(blockUndo, blockindex) && ReadBlockFromDisk(block, blockindex, Params().GetConsensus()))) {
+        !(UndoReadFromDisk(chainman.BlocksDirPath(), blockUndo, blockindex) && ReadBlockFromDisk(chainman.BlocksDirPath(), block, blockindex, Params().GetConsensus()))) {
         TxToJSON(*tx, hash_block, result, chainman.ActiveChainstate());
         return result;
     }

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -85,7 +85,7 @@ static RPCHelpMan gettxoutproof()
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock);
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock, chainman.BlocksDirPath());
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }
@@ -98,7 +98,7 @@ static RPCHelpMan gettxoutproof()
             }
 
             CBlock block;
-            if (!ReadBlockFromDisk(block, pblockindex, chainman.GetConsensus())) {
+            if (!ReadBlockFromDisk(chainman.BlocksDirPath(), block, pblockindex, chainman.GetConsensus())) {
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
             }
 

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -18,7 +18,6 @@
 #include <validation.h>
 
 using node::GetTransaction;
-using node::ReadBlockFromDisk;
 
 static RPCHelpMan gettxoutproof()
 {
@@ -85,7 +84,7 @@ static RPCHelpMan gettxoutproof()
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock, chainman.BlocksDirPath(), chainman.FastPrune());
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock, chainman.m_blockman);
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }
@@ -98,7 +97,7 @@ static RPCHelpMan gettxoutproof()
             }
 
             CBlock block;
-            if (!ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, pblockindex, chainman.GetConsensus())) {
+            if (!chainman.m_blockman.ReadBlockFromDisk(block, pblockindex, chainman.GetConsensus())) {
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
             }
 

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -85,7 +85,7 @@ static RPCHelpMan gettxoutproof()
             }
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock, chainman.BlocksDirPath());
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock, chainman.BlocksDirPath(), chainman.FastPrune());
                 if (!tx || hashBlock.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }
@@ -98,7 +98,7 @@ static RPCHelpMan gettxoutproof()
             }
 
             CBlock block;
-            if (!ReadBlockFromDisk(chainman.BlocksDirPath(), block, pblockindex, chainman.GetConsensus())) {
+            if (!ReadBlockFromDisk(chainman.BlocksDirPath(), chainman.FastPrune(), block, pblockindex, chainman.GetConsensus())) {
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
             }
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -28,7 +28,7 @@ struct BuildChainTestingSetup : public TestChain100Setup {
     bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script_pub_key, size_t length, std::vector<std::shared_ptr<CBlock>>& chain);
 };
 
-static bool CheckFilterLookups(node::BlockManager& blockman, BlockFilterIndex& filter_index, const CBlockIndex* block_index,
+static bool CheckFilterLookups(const node::BlockManager& blockman, BlockFilterIndex& filter_index, const CBlockIndex* block_index,
                                uint256& last_header)
 {
     BlockFilter expected_filter;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -28,11 +28,11 @@ struct BuildChainTestingSetup : public TestChain100Setup {
     bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script_pub_key, size_t length, std::vector<std::shared_ptr<CBlock>>& chain);
 };
 
-static bool CheckFilterLookups(const fs::path& blocks_dir, BlockFilterIndex& filter_index, const CBlockIndex* block_index,
+static bool CheckFilterLookups(const fs::path& blocks_dir, const bool fast_prune, BlockFilterIndex& filter_index, const CBlockIndex* block_index,
                                uint256& last_header)
 {
     BlockFilter expected_filter;
-    if (!ComputeFilter(blocks_dir, filter_index.GetFilterType(), block_index, expected_filter)) {
+    if (!ComputeFilter(blocks_dir, fast_prune, filter_index.GetFilterType(), block_index, expected_filter)) {
         BOOST_ERROR("ComputeFilter failed on block " << block_index->nHeight);
         return false;
     }
@@ -155,7 +155,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         for (block_index = m_node.chainman->ActiveChain().Genesis();
              block_index != nullptr;
              block_index = m_node.chainman->ActiveChain().Next(block_index)) {
-            CheckFilterLookups(m_args.GetBlocksDirPath(), filter_index, block_index, last_header);
+            CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, last_header);
         }
     }
 
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-        CheckFilterLookups(m_args.GetBlocksDirPath(), filter_index, block_index, chainA_last_header);
+        CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainA_last_header);
     }
 
     // Reorg to chain B.
@@ -207,7 +207,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-        CheckFilterLookups(m_args.GetBlocksDirPath(), filter_index, block_index, chainB_last_header);
+        CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainB_last_header);
     }
 
     // Check that filters for stale blocks on A can be retrieved.
@@ -221,7 +221,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-        CheckFilterLookups(m_args.GetBlocksDirPath(), filter_index, block_index, chainA_last_header);
+        CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainA_last_header);
     }
 
     // Reorg back to chain A.
@@ -241,14 +241,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
              block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainA[i]->GetHash());
          }
          BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-         CheckFilterLookups(m_args.GetBlocksDirPath(), filter_index, block_index, chainA_last_header);
+         CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainA_last_header);
 
          {
              LOCK(cs_main);
              block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainB[i]->GetHash());
          }
          BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-         CheckFilterLookups(m_args.GetBlocksDirPath(), filter_index, block_index, chainB_last_header);
+         CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainB_last_header);
      }
 
     // Test lookups for a range of filters/hashes.

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -28,11 +28,11 @@ struct BuildChainTestingSetup : public TestChain100Setup {
     bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script_pub_key, size_t length, std::vector<std::shared_ptr<CBlock>>& chain);
 };
 
-static bool CheckFilterLookups(const fs::path& blocks_dir, const bool fast_prune, BlockFilterIndex& filter_index, const CBlockIndex* block_index,
+static bool CheckFilterLookups(node::BlockManager& blockman, BlockFilterIndex& filter_index, const CBlockIndex* block_index,
                                uint256& last_header)
 {
     BlockFilter expected_filter;
-    if (!ComputeFilter(blocks_dir, fast_prune, filter_index.GetFilterType(), block_index, expected_filter)) {
+    if (!ComputeFilter(blockman, filter_index.GetFilterType(), block_index, expected_filter)) {
         BOOST_ERROR("ComputeFilter failed on block " << block_index->nHeight);
         return false;
     }
@@ -155,7 +155,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         for (block_index = m_node.chainman->ActiveChain().Genesis();
              block_index != nullptr;
              block_index = m_node.chainman->ActiveChain().Next(block_index)) {
-            CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, last_header);
+            CheckFilterLookups(m_node.chainman->m_blockman, filter_index, block_index, last_header);
         }
     }
 
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-        CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainA_last_header);
+        CheckFilterLookups(m_node.chainman->m_blockman, filter_index, block_index, chainA_last_header);
     }
 
     // Reorg to chain B.
@@ -207,7 +207,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-        CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainB_last_header);
+        CheckFilterLookups(m_node.chainman->m_blockman, filter_index, block_index, chainB_last_header);
     }
 
     // Check that filters for stale blocks on A can be retrieved.
@@ -221,7 +221,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         }
 
         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-        CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainA_last_header);
+        CheckFilterLookups(m_node.chainman->m_blockman, filter_index, block_index, chainA_last_header);
     }
 
     // Reorg back to chain A.
@@ -241,14 +241,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
              block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainA[i]->GetHash());
          }
          BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-         CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainA_last_header);
+         CheckFilterLookups(m_node.chainman->m_blockman, filter_index, block_index, chainA_last_header);
 
          {
              LOCK(cs_main);
              block_index = m_node.chainman->m_blockman.LookupBlockIndex(chainB[i]->GetHash());
          }
          BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
-         CheckFilterLookups(m_args.GetBlocksDirPath(), m_args.GetBoolArg("-fastprune", false), filter_index, block_index, chainB_last_header);
+         CheckFilterLookups(m_node.chainman->m_blockman, filter_index, block_index, chainB_last_header);
      }
 
     // Test lookups for a range of filters/hashes.

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -19,7 +19,7 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
     const auto params {CreateChainParams(gArgs, CBaseChainParams::MAIN)};
-    BlockManager blockman {gArgs.GetBlocksDirPath()};
+    BlockManager blockman {gArgs.GetBlocksDirPath(), gArgs.GetBoolArg("-fastprune", false)};
     CChain chain {};
     // simulate adding a genesis block normally
     BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, chain, *params, nullptr).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <node/blockmanager_args.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <validation.h>
@@ -11,6 +12,7 @@
 #include <test/util/setup_common.h>
 
 using node::BlockManager;
+using node::ApplyArgsManOptions;
 using node::BLOCK_SERIALIZATION_HEADER_SIZE;
 
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
@@ -19,7 +21,11 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
     const auto params {CreateChainParams(gArgs, CBaseChainParams::MAIN)};
-    BlockManager blockman {gArgs.GetBlocksDirPath(), gArgs.GetBoolArg("-fastprune", false)};
+    BlockManager::Options blockman_opts{
+        .blocks_dir = gArgs.GetBlocksDirPath(),
+    };
+    ApplyArgsManOptions(gArgs, blockman_opts);
+    BlockManager blockman {blockman_opts};
     CChain chain {};
     // simulate adding a genesis block normally
     BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, chain, *params, nullptr).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -18,8 +18,8 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
-    const auto params {CreateChainParams(ArgsManager{}, CBaseChainParams::MAIN)};
-    BlockManager blockman {};
+    const auto params {CreateChainParams(gArgs, CBaseChainParams::MAIN)};
+    BlockManager blockman {gArgs.GetBlocksDirPath()};
     CChain chain {};
     // simulate adding a genesis block normally
     BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, chain, *params, nullptr).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -11,17 +11,17 @@
 using node::ReadBlockFromDisk;
 using node::UndoReadFromDisk;
 
-bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
+bool ComputeFilter(const fs::path& blocks_dir, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {
     LOCK(::cs_main);
 
     CBlock block;
-    if (!ReadBlockFromDisk(block, block_index->GetBlockPos(), Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(blocks_dir, block, block_index->GetBlockPos(), Params().GetConsensus())) {
         return false;
     }
 
     CBlockUndo block_undo;
-    if (block_index->nHeight > 0 && !UndoReadFromDisk(block_undo, block_index)) {
+    if (block_index->nHeight > 0 && !UndoReadFromDisk(blocks_dir, block_undo, block_index)) {
         return false;
     }
 

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -5,23 +5,21 @@
 #include <test/util/blockfilter.h>
 
 #include <chainparams.h>
-#include <node/blockstorage.h>
 #include <validation.h>
 
 using node::ReadBlockFromDisk;
-using node::UndoReadFromDisk;
 
-bool ComputeFilter(const fs::path& blocks_dir, const bool fast_prune, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
+bool ComputeFilter(node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {
     LOCK(::cs_main);
 
     CBlock block;
-    if (!ReadBlockFromDisk(blocks_dir, fast_prune, block, block_index->GetBlockPos(), Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(blockman.BlocksDirPath(), blockman.FastPrune(), block, block_index->GetBlockPos(), Params().GetConsensus())) {
         return false;
     }
 
     CBlockUndo block_undo;
-    if (block_index->nHeight > 0 && !UndoReadFromDisk(blocks_dir, block_undo, block_index)) {
+    if (block_index->nHeight > 0 && !blockman.UndoReadFromDisk(block_undo, block_index)) {
         return false;
     }
 

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -7,14 +7,12 @@
 #include <chainparams.h>
 #include <validation.h>
 
-using node::ReadBlockFromDisk;
-
 bool ComputeFilter(node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {
     LOCK(::cs_main);
 
     CBlock block;
-    if (!ReadBlockFromDisk(blockman.BlocksDirPath(), blockman.FastPrune(), block, block_index->GetBlockPos(), Params().GetConsensus())) {
+    if (!blockman.ReadBlockFromDisk(block, block_index->GetBlockPos(), Params().GetConsensus())) {
         return false;
     }
 

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -11,12 +11,12 @@
 using node::ReadBlockFromDisk;
 using node::UndoReadFromDisk;
 
-bool ComputeFilter(const fs::path& blocks_dir, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
+bool ComputeFilter(const fs::path& blocks_dir, const bool fast_prune, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {
     LOCK(::cs_main);
 
     CBlock block;
-    if (!ReadBlockFromDisk(blocks_dir, block, block_index->GetBlockPos(), Params().GetConsensus())) {
+    if (!ReadBlockFromDisk(blocks_dir, fast_prune, block, block_index->GetBlockPos(), Params().GetConsensus())) {
         return false;
     }
 

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -7,7 +7,7 @@
 #include <chainparams.h>
 #include <validation.h>
 
-bool ComputeFilter(node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
+bool ComputeFilter(const node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {
     LOCK(::cs_main);
 

--- a/src/test/util/blockfilter.h
+++ b/src/test/util/blockfilter.h
@@ -6,8 +6,10 @@
 #define BITCOIN_TEST_UTIL_BLOCKFILTER_H
 
 #include <blockfilter.h>
+#include <fs.h>
+
 class CBlockIndex;
 
-bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
+bool ComputeFilter(const fs::path& blocks_dir, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
 
 #endif // BITCOIN_TEST_UTIL_BLOCKFILTER_H

--- a/src/test/util/blockfilter.h
+++ b/src/test/util/blockfilter.h
@@ -6,10 +6,11 @@
 #define BITCOIN_TEST_UTIL_BLOCKFILTER_H
 
 #include <blockfilter.h>
+#include <node/blockstorage.h>
 #include <fs.h>
 
 class CBlockIndex;
 
-bool ComputeFilter(const fs::path& blocks_dir, const bool fast_prune, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
+bool ComputeFilter(node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
 
 #endif // BITCOIN_TEST_UTIL_BLOCKFILTER_H

--- a/src/test/util/blockfilter.h
+++ b/src/test/util/blockfilter.h
@@ -11,6 +11,6 @@
 
 class CBlockIndex;
 
-bool ComputeFilter(node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
+bool ComputeFilter(const node::BlockManager& blockman, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
 
 #endif // BITCOIN_TEST_UTIL_BLOCKFILTER_H

--- a/src/test/util/blockfilter.h
+++ b/src/test/util/blockfilter.h
@@ -10,6 +10,6 @@
 
 class CBlockIndex;
 
-bool ComputeFilter(const fs::path& blocks_dir, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
+bool ComputeFilter(const fs::path& blocks_dir, const bool fast_prune, BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
 
 #endif // BITCOIN_TEST_UTIL_BLOCKFILTER_H

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -182,6 +182,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
         .chainparams = chainparams,
         .adjusted_time_callback = GetAdjustedTime,
         .check_block_index = true,
+        .blocks_dir = m_args.GetBlocksDirPath(),
     };
     m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts);
     m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(m_cache_sizes.block_tree_db, true);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -20,6 +20,7 @@
 #include <kernel/mempool_entry.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/blockmanager_args.h>
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
 #include <node/context.h>
@@ -60,6 +61,7 @@
 using kernel::ValidationCacheSizes;
 using node::ApplyArgsManOptions;
 using node::BlockAssembler;
+using node::BlockManager;
 using node::CalculateCacheSizes;
 using node::LoadChainstate;
 using node::RegenerateCommitments;
@@ -182,9 +184,13 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
         .chainparams = chainparams,
         .adjusted_time_callback = GetAdjustedTime,
         .check_block_index = true,
+    };
+    BlockManager::Options blockman_opts{
         .blocks_dir = m_args.GetBlocksDirPath(),
     };
-    m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts);
+    node::ApplyArgsManOptions(m_args, blockman_opts);
+
+    m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
     m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(m_cache_sizes.block_tree_db, true);
 
     constexpr int script_check_threads = 2;

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -375,6 +375,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             const ChainstateManager::Options chainman_opts{
                 .chainparams = ::Params(),
                 .adjusted_time_callback = GetAdjustedTime,
+                .blocks_dir = gArgs.GetBlocksDirPath(),
             };
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -4,6 +4,7 @@
 //
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <node/blockmanager_args.h>
 #include <node/utxo_snapshot.h>
 #include <random.h>
 #include <rpc/blockchain.h>
@@ -21,6 +22,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::ApplyArgsManOptions;
+using node::BlockManager;
 using node::SnapshotMetadata;
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, ChainTestingSetup)
@@ -375,12 +378,15 @@ struct SnapshotTestSetup : TestChain100Setup {
             const ChainstateManager::Options chainman_opts{
                 .chainparams = ::Params(),
                 .adjusted_time_callback = GetAdjustedTime,
+            };
+            BlockManager::Options blockman_opts{
                 .blocks_dir = gArgs.GetBlocksDirPath(),
             };
+            ApplyArgsManOptions(gArgs, blockman_opts);
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.
             m_node.chainman.reset();
-            m_node.chainman.reset(new ChainstateManager(chainman_opts));
+            m_node.chainman.reset(new ChainstateManager(chainman_opts, blockman_opts));
         }
         return *Assert(m_node.chainman);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5309,7 +5309,7 @@ static ChainstateManager::Options&& Flatten(ChainstateManager::Options&& opts)
     return std::move(opts);
 }
 
-ChainstateManager::ChainstateManager(Options options) : m_options{Flatten(std::move(options))}, m_blockman{options.blocks_dir, options.fast_prune} {}
+ChainstateManager::ChainstateManager(Options options, BlockManager::Options blockman_options) : m_options{Flatten(std::move(options))}, m_blockman{blockman_options} {}
 
 ChainstateManager::~ChainstateManager()
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -79,7 +79,6 @@ using node::CBlockIndexWorkComparator;
 using node::fReindex;
 using node::ReadBlockFromDisk;
 using node::SnapshotMetadata;
-using node::UndoReadFromDisk;
 
 /** Maximum kilobytes for transactions to store for processing during reorg */
 static const unsigned int MAX_DISCONNECTED_TX_POOL_SIZE = 20000;
@@ -1859,7 +1858,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
     bool fClean = true;
 
     CBlockUndo blockUndo;
-    if (!UndoReadFromDisk(m_blockman.m_blocks_dir, blockUndo, pindex)) {
+    if (!m_blockman.UndoReadFromDisk(blockUndo, pindex)) {
         error("DisconnectBlock(): failure reading undo data");
         return DISCONNECT_FAILED;
     }
@@ -4116,7 +4115,7 @@ bool CVerifyDB::VerifyDB(
         if (nCheckLevel >= 2 && pindex) {
             CBlockUndo undo;
             if (!pindex->GetUndoPos().IsNull()) {
-                if (!UndoReadFromDisk(chainstate.BlocksDirPath(), undo, pindex)) {
+                if (!chainstate.m_blockman.UndoReadFromDisk(undo, pindex)) {
                     return error("VerifyDB(): *** found bad undo data at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 }
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -80,7 +80,6 @@ using node::fReindex;
 using node::ReadBlockFromDisk;
 using node::SnapshotMetadata;
 using node::UndoReadFromDisk;
-using node::UnlinkPrunedFiles;
 
 /** Maximum kilobytes for transactions to store for processing during reorg */
 static const unsigned int MAX_DISCONNECTED_TX_POOL_SIZE = 20000;
@@ -1860,7 +1859,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
     bool fClean = true;
 
     CBlockUndo blockUndo;
-    if (!UndoReadFromDisk(blockUndo, pindex)) {
+    if (!UndoReadFromDisk(m_blockman.m_blocks_dir, blockUndo, pindex)) {
         error("DisconnectBlock(): failure reading undo data");
         return DISCONNECT_FAILED;
     }
@@ -2491,7 +2490,7 @@ bool Chainstate::FlushStateToDisk(
             if (fFlushForPrune) {
                 LOG_TIME_MILLIS_WITH_CATEGORY("unlink pruned files", BCLog::BENCH);
 
-                UnlinkPrunedFiles(setFilesToPrune);
+                m_blockman.UnlinkPrunedFiles(setFilesToPrune);
             }
             m_last_write = nNow;
         }
@@ -2655,7 +2654,7 @@ bool Chainstate::DisconnectTip(BlockValidationState& state, DisconnectedBlockTra
     // Read block from disk.
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
     CBlock& block = *pblock;
-    if (!ReadBlockFromDisk(block, pindexDelete, m_chainman.GetConsensus())) {
+    if (!ReadBlockFromDisk(m_blockman.m_blocks_dir, block, pindexDelete, m_chainman.GetConsensus())) {
         return error("DisconnectTip(): Failed to read block");
     }
     // Apply the block atomically to the chain state.
@@ -2772,7 +2771,7 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
     std::shared_ptr<const CBlock> pthisBlock;
     if (!pblock) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
-        if (!ReadBlockFromDisk(*pblockNew, pindexNew, m_chainman.GetConsensus())) {
+        if (!ReadBlockFromDisk(m_blockman.m_blocks_dir, *pblockNew, pindexNew, m_chainman.GetConsensus())) {
             return AbortNode(state, "Failed to read block");
         }
         pthisBlock = pblockNew;
@@ -4105,7 +4104,7 @@ bool CVerifyDB::VerifyDB(
         }
         CBlock block;
         // check level 0: read from disk
-        if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
+        if (!ReadBlockFromDisk(chainstate.BlocksDirPath(), block, pindex, consensus_params)) {
             return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         }
         // check level 1: verify block validity
@@ -4117,7 +4116,7 @@ bool CVerifyDB::VerifyDB(
         if (nCheckLevel >= 2 && pindex) {
             CBlockUndo undo;
             if (!pindex->GetUndoPos().IsNull()) {
-                if (!UndoReadFromDisk(undo, pindex)) {
+                if (!UndoReadFromDisk(chainstate.BlocksDirPath(), undo, pindex)) {
                     return error("VerifyDB(): *** found bad undo data at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 }
             }
@@ -4165,7 +4164,7 @@ bool CVerifyDB::VerifyDB(
             uiInterface.ShowProgress(_("Verifying blocks…").translated, percentageDone, false);
             pindex = chainstate.m_chain.Next(pindex);
             CBlock block;
-            if (!ReadBlockFromDisk(block, pindex, consensus_params))
+            if (!ReadBlockFromDisk(chainstate.BlocksDirPath(), block, pindex, consensus_params))
                 return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             if (!chainstate.ConnectBlock(block, state, pindex, coins)) {
                 return error("VerifyDB(): *** found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
@@ -4185,7 +4184,7 @@ bool Chainstate::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& in
     AssertLockHeld(cs_main);
     // TODO: merge with ConnectBlock
     CBlock block;
-    if (!ReadBlockFromDisk(block, pindex, m_chainman.GetConsensus())) {
+    if (!ReadBlockFromDisk(m_blockman.m_blocks_dir, block, pindex, m_chainman.GetConsensus())) {
         return error("ReplayBlock(): ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
     }
 
@@ -4237,7 +4236,7 @@ bool Chainstate::ReplayBlocks()
     while (pindexOld != pindexFork) {
         if (pindexOld->nHeight > 0) { // Never disconnect the genesis block.
             CBlock block;
-            if (!ReadBlockFromDisk(block, pindexOld, m_chainman.GetConsensus())) {
+            if (!ReadBlockFromDisk(m_blockman.m_blocks_dir, block, pindexOld, m_chainman.GetConsensus())) {
                 return error("RollbackBlock(): ReadBlockFromDisk() failed at %d, hash=%s", pindexOld->nHeight, pindexOld->GetBlockHash().ToString());
             }
             LogPrintf("Rolling back %s (%i)\n", pindexOld->GetBlockHash().ToString(), pindexOld->nHeight);
@@ -4526,7 +4525,7 @@ void Chainstate::LoadExternalBlockFile(
                     while (range.first != range.second) {
                         std::multimap<uint256, FlatFilePos>::iterator it = range.first;
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
-                        if (ReadBlockFromDisk(*pblockrecursive, it->second, params.GetConsensus())) {
+                        if (ReadBlockFromDisk(m_blockman.m_blocks_dir, *pblockrecursive, it->second, params.GetConsensus())) {
                             LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, pblockrecursive->GetHash().ToString(),
                                     head.ToString());
                             LOCK(cs_main);
@@ -5312,7 +5311,7 @@ static ChainstateManager::Options&& Flatten(ChainstateManager::Options&& opts)
     return std::move(opts);
 }
 
-ChainstateManager::ChainstateManager(Options options) : m_options{Flatten(std::move(options))} {}
+ChainstateManager::ChainstateManager(Options options) : m_options{Flatten(std::move(options))}, m_blockman{options.blocks_dir} {}
 
 ChainstateManager::~ChainstateManager()
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -725,7 +725,8 @@ public:
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    fs::path BlocksDirPath() {return m_blockman.BlocksDirPath();}
+    const fs::path& BlocksDirPath() { return m_blockman.BlocksDirPath(); }
+    bool FastPrune() { return m_blockman.FastPrune(); }
 
 private:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
@@ -1062,9 +1063,8 @@ public:
     Chainstate& ActivateExistingSnapshot(CTxMemPool* mempool, uint256 base_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    fs::path BlocksDirPath() {
-        return m_blockman.BlocksDirPath();
-    }
+    const fs::path& BlocksDirPath() { return m_blockman.BlocksDirPath(); }
+    bool FastPrune() { return m_blockman.FastPrune(); }
 
     ~ChainstateManager();
 };

--- a/src/validation.h
+++ b/src/validation.h
@@ -872,7 +872,7 @@ private:
 public:
     using Options = kernel::ChainstateManagerOpts;
 
-    explicit ChainstateManager(Options options);
+    explicit ChainstateManager(Options options, node::BlockManager::Options blockman_options);
 
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }

--- a/src/validation.h
+++ b/src/validation.h
@@ -725,6 +725,8 @@ public:
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    fs::path BlocksDirPath() {return m_blockman.BlocksDirPath();}
+
 private:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
@@ -1059,6 +1061,10 @@ public:
     //! previously.
     Chainstate& ActivateExistingSnapshot(CTxMemPool* mempool, uint256 base_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    fs::path BlocksDirPath() {
+        return m_blockman.BlocksDirPath();
+    }
 
     ~ChainstateManager();
 };

--- a/src/validation.h
+++ b/src/validation.h
@@ -725,9 +725,6 @@ public:
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    const fs::path& BlocksDirPath() { return m_blockman.BlocksDirPath(); }
-    bool FastPrune() { return m_blockman.FastPrune(); }
-
 private:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
@@ -1062,9 +1059,6 @@ public:
     //! previously.
     Chainstate& ActivateExistingSnapshot(CTxMemPool* mempool, uint256 base_blockhash)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-
-    const fs::path& BlocksDirPath() { return m_blockman.BlocksDirPath(); }
-    bool FastPrune() { return m_blockman.FastPrune(); }
 
     ~ChainstateManager();
 };

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -29,7 +29,6 @@
 #include <univalue.h>
 
 using node::MAX_BLOCKFILE_SIZE;
-using node::UnlinkPrunedFiles;
 
 namespace wallet {
 RPCHelpMan importmulti();
@@ -159,7 +158,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
         file_number = oldTip->GetBlockPos().nFile;
         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
     }
-    UnlinkPrunedFiles({file_number});
+    m_node.chainman->m_blockman.UnlinkPrunedFiles({file_number});
 
     // Verify ScanForWalletTransactions only picks transactions in the new block
     // file.
@@ -188,7 +187,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
         file_number = newTip->GetBlockPos().nFile;
         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
     }
-    UnlinkPrunedFiles({file_number});
+    m_node.chainman->m_blockman.UnlinkPrunedFiles({file_number});
 
     // Verify ScanForWalletTransactions scans no blocks.
     {
@@ -226,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
         file_number = oldTip->GetBlockPos().nFile;
         Assert(m_node.chainman)->m_blockman.PruneOneBlockFile(file_number);
     }
-    UnlinkPrunedFiles({file_number});
+    m_node.chainman->m_blockman.UnlinkPrunedFiles({file_number});
 
     // Verify importmulti RPC returns failure for a key whose creation time is
     // before the missing block, and success for a key whose creation time is

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -19,6 +19,7 @@
 #include <streams.h>
 #include <sync.h>
 #include <uint256.h>
+#include <util/system.h>
 #include <version.h>
 #include <zmq/zmqutil.h>
 
@@ -250,7 +251,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     const Consensus::Params& consensusParams = Params().GetConsensus();
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
     CBlock block;
-    if (!ReadBlockFromDisk(block, pindex, consensusParams)) {
+    if (!ReadBlockFromDisk(gArgs.GetBlocksDirPath(), gArgs.GetBoolArg("-fastprune", false), block, pindex, consensusParams)) {
         zmqError("Can't read block from disk");
         return false;
     }


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
