### PR TITLE
Chainstate rm kernel UI interface 0

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -54,6 +54,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
            src/kernel \
            src/node/blockmanager_args.cpp \
            src/node/chainstate.cpp \
+           src/node/chainstatemanager_notifications.cpp \
            src/node/chainstatemanager_args.cpp \
            src/node/mempool_args.cpp \
            src/node/minisketchwrapper.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -278,6 +278,7 @@ BITCOIN_CORE_H = \
   txrequest.h \
   undo.h \
   util/asmap.h \
+  util/batchpriority.h \
   util/bip32.h \
   util/bitdeque.h \
   util/bytevectorhash.h \
@@ -708,6 +709,7 @@ libbitcoin_util_a_SOURCES = \
   support/cleanse.cpp \
   sync.cpp \
   util/asmap.cpp \
+  util/batchpriority.cpp \
   util/bip32.cpp \
   util/bytevectorhash.cpp \
   util/chaintype.cpp \
@@ -960,6 +962,7 @@ libbitcoinkernel_la_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   uint256.cpp \
+  util/batchpriority.cpp \
   util/chaintype.cpp \
   util/check.cpp \
   util/exception.cpp \
@@ -975,7 +978,6 @@ libbitcoinkernel_la_SOURCES = \
   util/string.cpp \
   util/syscall_sandbox.cpp \
   util/syserror.cpp \
-  util/system.cpp \
   util/thread.cpp \
   util/threadnames.cpp \
   util/time.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -207,6 +207,7 @@ BITCOIN_CORE_H = \
   node/caches.h \
   node/chainstate.h \
   node/chainstatemanager_args.h \
+  node/chainstatemanager_notifications.h \
   node/coin.h \
   node/coins_view_args.h \
   node/connection_types.h \
@@ -399,6 +400,7 @@ libbitcoin_node_a_SOURCES = \
   node/caches.cpp \
   node/chainstate.cpp \
   node/chainstatemanager_args.cpp \
+  node/chainstatemanager_notifications.cpp \
   node/coin.cpp \
   node/coins_view_args.cpp \
   node/connection_types.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,6 +143,7 @@ BITCOIN_CORE_H = \
   compat/compat.h \
   compat/cpuid.h \
   compat/endian.h \
+  common/system.h \
   compressor.h \
   consensus/consensus.h \
   consensus/tx_check.h \
@@ -310,7 +311,6 @@ BITCOIN_CORE_H = \
   util/string.h \
   util/syscall_sandbox.h \
   util/syserror.h \
-  util/system.h \
   util/thread.h \
   util/threadinterrupt.h \
   util/threadnames.h \
@@ -658,6 +658,7 @@ libbitcoin_common_a_SOURCES = \
   common/init.cpp \
   common/interfaces.cpp \
   common/run_command.cpp \
+  common/system.cpp \
   compressor.cpp \
   core_read.cpp \
   core_write.cpp \
@@ -723,7 +724,6 @@ libbitcoin_util_a_SOURCES = \
   util/hasher.cpp \
   util/sock.cpp \
   util/syserror.cpp \
-  util/system.cpp \
   util/message.cpp \
   util/moneystr.cpp \
   util/rbf.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -934,7 +934,6 @@ libbitcoinkernel_la_SOURCES = \
   logging.cpp \
   node/blockstorage.cpp \
   node/chainstate.cpp \
-  node/interface_ui.cpp \
   node/utxo_snapshot.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -5,11 +5,11 @@
 
 #include <banman.h>
 
+#include <common/system.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <node/interface_ui.h>
 #include <sync.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -4,11 +4,11 @@
 
 #include <bench/bench.h>
 #include <checkqueue.h>
+#include <common/system.h>
 #include <key.h>
 #include <prevector.h>
 #include <pubkey.h>
 #include <random.h>
-#include <util/system.h>
 
 #include <vector>
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -91,6 +91,7 @@ int main(int argc, char* argv[])
             .notify_header_tip = [](SynchronizationState, int64_t height, int64_t timestamp, bool presync) { std::cout << "Header tip changed: " << height << ", " << timestamp << ", " << presync << std::endl; },
             .show_progress = [](const std::string& title, int nProgress, bool resume_possible) { std::cout << "Progress: " << title << ", " << nProgress << ", " << resume_possible << std::endl; },
             .do_warning = [](const bilingual_str& warning) { std::cout << "Warning: " << warning.original << std::endl; },
+            .init_error = [](const bilingual_str& user_message) { std::cout << "Init error: " << user_message.original << std::endl; },
         },
     };
     const node::BlockManager::Options blockman_opts{

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -86,6 +86,9 @@ int main(int argc, char* argv[])
         .chainparams = *chainparams,
         .datadir = gArgs.GetDataDirNet(),
         .adjusted_time_callback = NodeClock::now,
+        .notification_callbacks = ChainstateManager::NotificationCallbacks{
+            .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { std::cout << "Block tip changed" << std::endl; },
+        },
     };
     const node::BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -90,6 +90,7 @@ int main(int argc, char* argv[])
             .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { std::cout << "Block tip changed" << std::endl; },
             .notify_header_tip = [](SynchronizationState, int64_t height, int64_t timestamp, bool presync) { std::cout << "Header tip changed: " << height << ", " << timestamp << ", " << presync << std::endl; },
             .show_progress = [](const std::string& title, int nProgress, bool resume_possible) { std::cout << "Progress: " << title << ", " << nProgress << ", " << resume_possible << std::endl; },
+            .do_warning = [](const bilingual_str& warning) { std::cout << "Warning: " << warning.original << std::endl; },
         },
     };
     const node::BlockManager::Options blockman_opts{

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -88,6 +88,7 @@ int main(int argc, char* argv[])
         .adjusted_time_callback = NodeClock::now,
         .notification_callbacks = ChainstateManager::NotificationCallbacks{
             .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { std::cout << "Block tip changed" << std::endl; },
+            .notify_header_tip = [](SynchronizationState, int64_t height, int64_t timestamp, bool presync) { std::cout << "Header tip changed: " << height << ", " << timestamp << ", " << presync << std::endl; },
         },
     };
     const node::BlockManager::Options blockman_opts{

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -89,6 +89,7 @@ int main(int argc, char* argv[])
         .notification_callbacks = ChainstateManager::NotificationCallbacks{
             .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { std::cout << "Block tip changed" << std::endl; },
             .notify_header_tip = [](SynchronizationState, int64_t height, int64_t timestamp, bool presync) { std::cout << "Header tip changed: " << height << ", " << timestamp << ", " << presync << std::endl; },
+            .show_progress = [](const std::string& title, int nProgress, bool resume_possible) { std::cout << "Progress: " << title << ", " << nProgress << ", " << resume_possible << std::endl; },
         },
     };
     const node::BlockManager::Options blockman_opts{

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -10,6 +10,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>
@@ -23,7 +24,6 @@
 #include <util/chaintype.h>
 #include <util/exception.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -10,6 +10,7 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
@@ -27,7 +28,6 @@
 #include <util/rbf.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <cstdio>

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -12,11 +12,11 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <compat/compat.h>
 #include <core_io.h>
 #include <streams.h>
 #include <util/exception.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <version.h>
 

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -10,6 +10,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <interfaces/init.h>
@@ -18,7 +19,6 @@
 #include <pubkey.h>
 #include <tinyformat.h>
 #include <util/exception.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallettool.h>
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -11,6 +11,7 @@
 #include <clientversion.h>
 #include <common/args.h>
 #include <common/init.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <init.h>
@@ -25,7 +26,6 @@
 #include <util/strencodings.h>
 #include <util/syscall_sandbox.h>
 #include <util/syserror.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 #include <util/tokenpipe.h>
 #include <util/translation.h>

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -3,16 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blockencodings.h>
+#include <chainparams.h>
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
-#include <chainparams.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>
 #include <validation.h>
-#include <util/system.h>
 
 #include <unordered_map>
 

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
+#include <common/system.h>
 
 #include <logging.h>
 #include <util/string.h>

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_SYSTEM_H
-#define BITCOIN_UTIL_SYSTEM_H
+#ifndef BITCOIN_COMMON_SYSTEM_H
+#define BITCOIN_COMMON_SYSTEM_H
 
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
@@ -62,4 +62,4 @@ T* AnyPtr(const std::any& any) noexcept
 
 } // namespace util
 
-#endif // BITCOIN_UTIL_SYSTEM_H
+#endif // BITCOIN_COMMON_SYSTEM_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -4,6 +4,7 @@
 
 #include <core_io.h>
 
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
@@ -17,7 +18,6 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <map>
 #include <string>

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_EXTERNAL_SIGNER_H
 #define BITCOIN_EXTERNAL_SIGNER_H
 
+#include <common/system.h>
 #include <univalue.h>
-#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,6 +20,7 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
 #include <hash.h>
@@ -80,7 +81,6 @@
 #include <util/string.h>
 #include <util/syscall_sandbox.h>
 #include <util/syserror.h>
-#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadnames.h>
 #include <util/translation.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -87,6 +87,7 @@
 #include <validation.h>
 #include <validationinterface.h>
 #include <walletinitinterface.h>
+#include <warnings.h>
 
 #include <algorithm>
 #include <condition_variable>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1455,7 +1455,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = args.GetBlocksDirPath(),
-    };
+        .init_error_callback = [](const bilingual_str& user_message) {
+            InitError(user_message);
+        }};
     Assert(!ApplyArgsManOptions(args, blockman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 
     // cache size calculations

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -43,6 +43,7 @@
 #include <node/caches.h>
 #include <node/chainstate.h>
 #include <node/chainstatemanager_args.h>
+#include <node/chainstatemanager_notifications.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
 #include <node/mempool_args.h>
@@ -122,6 +123,7 @@ using node::CacheSizes;
 using node::CalculateCacheSizes;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINTPRIORITY;
+using node::DefaultChainstateManagerNotifications;
 using node::fReindex;
 using node::LoadChainstate;
 using node::MempoolPath;
@@ -1445,6 +1447,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         .chainparams = chainparams,
         .datadir = args.GetDataDirNet(),
         .adjusted_time_callback = GetAdjustedTime,
+        .notification_callbacks = DefaultChainstateManagerNotifications(),
     };
     Assert(!ApplyArgsManOptions(args, chainman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <ipc/capnp/protocol.h>
@@ -10,7 +11,6 @@
 #include <logging.h>
 #include <tinyformat.h>
 #include <util/fs.h>
-#include <util/system.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/kernel/blockmanager_opts.h
+++ b/src/kernel/blockmanager_opts.h
@@ -6,6 +6,7 @@
 #define BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
 
 #include <util/fs.h>
+#include <util/translation.h>
 
 #include <cstdint>
 
@@ -25,6 +26,7 @@ struct BlockManagerOpts {
     bool fast_prune{false};
     bool stop_after_block_import{DEFAULT_STOPAFTERBLOCKIMPORT};
     const fs::path blocks_dir;
+    const std::function<void(const bilingual_str& str)> init_error_callback;
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -35,6 +35,7 @@ struct ChainstateManagerNotificationCallbacks {
     const std::function<void(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)> notify_header_tip;
     const std::function<void(const std::string& title, int nProgress, bool resume_possible)> show_progress;
     const std::function<void(const bilingual_str& warning)> do_warning;
+    const std::function<void(const bilingual_str& user_message)> init_error;
 };
 
 /**

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -32,6 +32,7 @@ namespace kernel {
  */
 struct ChainstateManagerNotificationCallbacks {
     const std::function<void(SynchronizationState state, CBlockIndex* index)> notify_block_tip;
+    const std::function<void(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)> notify_header_tip;
 };
 
 /**

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -33,6 +33,7 @@ namespace kernel {
 struct ChainstateManagerNotificationCallbacks {
     const std::function<void(SynchronizationState state, CBlockIndex* index)> notify_block_tip;
     const std::function<void(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)> notify_header_tip;
+    const std::function<void(const std::string& title, int nProgress, bool resume_possible)> show_progress;
 };
 
 /**

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -34,6 +34,7 @@ struct ChainstateManagerNotificationCallbacks {
     const std::function<void(SynchronizationState state, CBlockIndex* index)> notify_block_tip;
     const std::function<void(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)> notify_header_tip;
     const std::function<void(const std::string& title, int nProgress, bool resume_possible)> show_progress;
+    const std::function<void(const bilingual_str& warning)> do_warning;
 };
 
 /**

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -15,12 +15,24 @@
 #include <functional>
 #include <optional>
 
+class CBlockIndex;
 class CChainParams;
+enum class SynchronizationState;
 
 static constexpr bool DEFAULT_CHECKPOINTS_ENABLED{true};
 static constexpr auto DEFAULT_MAX_TIP_AGE{24h};
 
 namespace kernel {
+
+/**
+ * A struct containing callback functions to issue notifications from the
+ * `ChainstateManager`. More ergonomically referred to as
+ * `ChainstateManager::NotificationCallbacks` due to the using-declaration in
+ * `ChainstateManager`.
+ */
+struct ChainstateManagerNotificationCallbacks {
+    const std::function<void(SynchronizationState state, CBlockIndex* index)> notify_block_tip;
+};
 
 /**
  * An options struct for `ChainstateManager`, more ergonomically referred to as
@@ -42,6 +54,8 @@ struct ChainstateManagerOpts {
     DBOptions block_tree_db{};
     DBOptions coins_db{};
     CoinsViewOptions coins_view{};
+
+    const ChainstateManagerNotificationCallbacks notification_callbacks;
 };
 
 } // namespace kernel

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -9,12 +9,12 @@
 #include <mapport.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <logging.h>
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <util/syscall_sandbox.h>
-#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>
 

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <net_permissions.h>
 #include <netbase.h>
 #include <util/error.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 const std::vector<std::string> NET_PERMISSIONS_DOC{

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -20,7 +20,6 @@
 #include <util/batchpriority.h>
 #include <util/fs.h>
 #include <util/syscall_sandbox.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <map>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -17,6 +17,7 @@
 #include <signet.h>
 #include <streams.h>
 #include <undo.h>
+#include <util/batchpriority.h>
 #include <util/fs.h>
 #include <util/syscall_sandbox.h>
 #include <util/system.h>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -527,7 +527,7 @@ void BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
     if (!UndoFileSeq().Flush(undo_pos_old, finalize)) {
-        AbortNode("Flushing undo file to disk failed. This is likely the result of an I/O error.");
+        AbortNode("Flushing undo file to disk failed. This is likely the result of an I/O error.", m_opts.init_error_callback);
     }
 }
 
@@ -546,7 +546,7 @@ void BlockManager::FlushBlockFile(bool fFinalize, bool finalize_undo)
 
     FlatFilePos block_pos_old(m_last_blockfile, m_blockfile_info[m_last_blockfile].nSize);
     if (!BlockFileSeq().Flush(block_pos_old, fFinalize)) {
-        AbortNode("Flushing block file to disk failed. This is likely the result of an I/O error.");
+        AbortNode("Flushing block file to disk failed. This is likely the result of an I/O error.", m_opts.init_error_callback);
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,
     // e.g. during IBD or a sync after a node going offline
@@ -658,7 +658,7 @@ bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigne
         bool out_of_space;
         size_t bytes_allocated = BlockFileSeq().Allocate(pos, nAddSize, out_of_space);
         if (out_of_space) {
-            return AbortNode("Disk space is too low!", _("Disk space is too low!"));
+            return AbortNode("Disk space is too low!", m_opts.init_error_callback, _("Disk space is too low!"));
         }
         if (bytes_allocated != 0 && IsPruneMode()) {
             m_check_for_pruning = true;
@@ -682,7 +682,7 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     bool out_of_space;
     size_t bytes_allocated = UndoFileSeq().Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
+        return AbortNode(state, "Disk space is too low!", m_opts.init_error_callback, _("Disk space is too low!"));
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
@@ -724,7 +724,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
             return error("ConnectBlock(): FindUndoPos failed");
         }
         if (!UndoWriteToDisk(blockundo, _pos, block.pprev->GetBlockHash(), GetParams().MessageStart())) {
-            return AbortNode(state, "Failed to write undo data");
+            return AbortNode(state, "Failed to write undo data", m_opts.init_error_callback);
         }
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
         // we want to flush the rev (undo) file once we've written the last block, which is indicated by the last height
@@ -842,7 +842,7 @@ FlatFilePos BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight, CCha
     }
     if (!position_known) {
         if (!WriteBlockToDisk(block, blockPos, GetParams().MessageStart())) {
-            AbortNode("Failed to write block");
+            AbortNode("Failed to write block", m_opts.init_error_callback);
             return FlatFilePos();
         }
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -154,7 +154,10 @@ public:
 
     explicit BlockManager(Options opts)
         : m_prune_mode{opts.prune_target > 0},
-          m_opts{std::move(opts)} {};
+          m_opts{std::move(opts)}
+    {
+        assert(m_opts.init_error_callback);
+    };
 
     std::atomic<bool> m_importing{false};
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -253,10 +253,7 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
                                                          "Only rebuild the block database if you are sure that your computer's date and time are correct")};
             }
 
-            VerifyDBResult result = CVerifyDB().VerifyDB(
-                *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
-                options.check_level,
-                options.check_blocks);
+            VerifyDBResult result = CVerifyDB(chainman.GetShowProgressCb()).VerifyDB(*chainstate, chainman.GetConsensus(), chainstate->CoinsDB(), options.check_level, options.check_blocks);
             switch (result) {
             case VerifyDBResult::SUCCESS:
             case VerifyDBResult::SKIPPED_MISSING_BLOCKS:

--- a/src/node/chainstatemanager_notifications.cpp
+++ b/src/node/chainstatemanager_notifications.cpp
@@ -65,6 +65,7 @@ ChainstateManagerNotificationCallbacks DefaultChainstateManagerNotifications()
         .notify_header_tip = [](SynchronizationState state, int64_t height, int64_t timestamp, bool presync) { uiInterface.NotifyHeaderTip(state, height, timestamp, presync); },
         .show_progress = [](const std::string& title, int nProgress, bool resume_possible) { uiInterface.ShowProgress(title, nProgress, resume_possible); },
         .do_warning = [](const bilingual_str& warning) { DoWarning(warning); },
+        .init_error = [](const bilingual_str& user_message) { InitError(user_message); },
     };
 }
 } // namespace node

--- a/src/node/chainstatemanager_notifications.cpp
+++ b/src/node/chainstatemanager_notifications.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <string>
 
 using kernel::ChainstateManagerNotificationCallbacks;
 
@@ -21,6 +22,7 @@ ChainstateManagerNotificationCallbacks DefaultChainstateManagerNotifications()
     return ChainstateManagerNotificationCallbacks{
         .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { uiInterface.NotifyBlockTip(state, index); },
         .notify_header_tip = [](SynchronizationState state, int64_t height, int64_t timestamp, bool presync) { uiInterface.NotifyHeaderTip(state, height, timestamp, presync); },
+        .show_progress = [](const std::string& title, int nProgress, bool resume_possible) { uiInterface.ShowProgress(title, nProgress, resume_possible); },
     };
 }
 } // namespace node

--- a/src/node/chainstatemanager_notifications.cpp
+++ b/src/node/chainstatemanager_notifications.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/chainstatemanager_notifications.h>
+
+#include <kernel/chainstatemanager_opts.h>
+#include <node/interface_ui.h>
+
+#include <functional>
+
+using kernel::ChainstateManagerNotificationCallbacks;
+
+class CBlockIndex;
+
+namespace node {
+
+ChainstateManagerNotificationCallbacks DefaultChainstateManagerNotifications()
+{
+    return ChainstateManagerNotificationCallbacks{
+        .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { uiInterface.NotifyBlockTip(state, index); },
+    };
+}
+} // namespace node

--- a/src/node/chainstatemanager_notifications.cpp
+++ b/src/node/chainstatemanager_notifications.cpp
@@ -7,6 +7,7 @@
 #include <kernel/chainstatemanager_opts.h>
 #include <node/interface_ui.h>
 
+#include <cstdint>
 #include <functional>
 
 using kernel::ChainstateManagerNotificationCallbacks;
@@ -19,6 +20,7 @@ ChainstateManagerNotificationCallbacks DefaultChainstateManagerNotifications()
 {
     return ChainstateManagerNotificationCallbacks{
         .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { uiInterface.NotifyBlockTip(state, index); },
+        .notify_header_tip = [](SynchronizationState state, int64_t height, int64_t timestamp, bool presync) { uiInterface.NotifyHeaderTip(state, height, timestamp, presync); },
     };
 }
 } // namespace node

--- a/src/node/chainstatemanager_notifications.cpp
+++ b/src/node/chainstatemanager_notifications.cpp
@@ -9,11 +9,11 @@
 #endif
 
 #include <common/args.h>
+#include <common/system.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <node/interface_ui.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <warnings.h>
 

--- a/src/node/chainstatemanager_notifications.cpp
+++ b/src/node/chainstatemanager_notifications.cpp
@@ -4,12 +4,23 @@
 
 #include <node/chainstatemanager_notifications.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <common/args.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <node/interface_ui.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/system.h>
+#include <util/translation.h>
+#include <warnings.h>
 
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <thread>
 
 using kernel::ChainstateManagerNotificationCallbacks;
 
@@ -17,12 +28,43 @@ class CBlockIndex;
 
 namespace node {
 
+static void AlertNotify(const std::string& strMessage)
+{
+    uiInterface.NotifyAlertChanged();
+#if HAVE_SYSTEM
+    std::string strCmd = gArgs.GetArg("-alertnotify", "");
+    if (strCmd.empty()) return;
+
+    // Alert text should be plain ascii coming from a trusted source, but to
+    // be safe we first strip anything not in safeChars, then add single quotes around
+    // the whole string before passing it to the shell:
+    std::string singleQuote("'");
+    std::string safeStatus = SanitizeString(strMessage);
+    safeStatus = singleQuote+safeStatus+singleQuote;
+    ReplaceAll(strCmd, "%s", safeStatus);
+
+    std::thread t(runCommand, strCmd);
+    t.detach(); // thread runs free
+#endif
+}
+
+static void DoWarning(const bilingual_str& warning)
+{
+    static bool fWarned = false;
+    SetMiscWarning(warning);
+    if (!fWarned) {
+        AlertNotify(warning.original);
+        fWarned = true;
+    }
+}
+
 ChainstateManagerNotificationCallbacks DefaultChainstateManagerNotifications()
 {
     return ChainstateManagerNotificationCallbacks{
         .notify_block_tip = [](SynchronizationState state, CBlockIndex* index) { uiInterface.NotifyBlockTip(state, index); },
         .notify_header_tip = [](SynchronizationState state, int64_t height, int64_t timestamp, bool presync) { uiInterface.NotifyHeaderTip(state, height, timestamp, presync); },
         .show_progress = [](const std::string& title, int nProgress, bool resume_possible) { uiInterface.ShowProgress(title, nProgress, resume_possible); },
+        .do_warning = [](const bilingual_str& warning) { DoWarning(warning); },
     };
 }
 } // namespace node

--- a/src/node/chainstatemanager_notifications.h
+++ b/src/node/chainstatemanager_notifications.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CHAINSTATEMANAGER_NOTIFICATIONS_H
+#define BITCOIN_NODE_CHAINSTATEMANAGER_NOTIFICATIONS_H
+
+#include <kernel/chainstatemanager_opts.h>
+
+namespace node {
+kernel::ChainstateManagerNotificationCallbacks DefaultChainstateManagerNotifications();
+} // namespace node
+
+#endif // BITCOIN_NODE_CHAINSTATEMANAGER_NOTIFICATIONS_H

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -4,9 +4,9 @@
 
 #include <node/txreconciliation.h>
 
+#include <common/system.h>
 #include <logging.h>
 #include <util/check.h>
-#include <util/system.h>
 
 #include <unordered_map>
 #include <variant>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -6,6 +6,7 @@
 #include <policy/fees.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
@@ -19,7 +20,6 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/serfloat.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <algorithm>

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -5,7 +5,7 @@
 
 #include <protocol.h>
 
-#include <util/system.h>
+#include <common/system.h>
 
 #include <atomic>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -11,6 +11,7 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <common/init.h>
+#include <common/system.h>
 #include <init.h>
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
@@ -32,7 +33,6 @@
 #include <uint256.h>
 #include <util/exception.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -30,13 +30,13 @@
 #include <qt/macdockiconhandler.h>
 #endif
 
-#include <functional>
 #include <chain.h>
 #include <chainparams.h>
+#include <common/system.h>
+#include <functional>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -12,11 +12,11 @@
 
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <net.h>
 #include <netbase.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 #include <util/time.h>
 #include <validation.h>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -15,11 +15,11 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 
+#include <common/system.h>
 #include <interfaces/node.h>
-#include <validation.h> // for DEFAULT_SCRIPTCHECK_THREADS and MAX_SCRIPTCHECK_THREADS
 #include <netbase.h>
-#include <txdb.h> // for -dbcache defaults
-#include <util/system.h>
+#include <txdb.h>       // for -dbcache defaults
+#include <validation.h> // for DEFAULT_SCRIPTCHECK_THREADS and MAX_SCRIPTCHECK_THREADS
 
 #include <chrono>
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -10,6 +10,7 @@
 #include <qt/forms/ui_debugwindow.h>
 
 #include <chainparams.h>
+#include <common/system.h>
 #include <interfaces/node.h>
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>
@@ -21,7 +22,6 @@
 #include <rpc/server.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 
 #include <univalue.h>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -9,13 +9,13 @@
 #include <qt/splashscreen.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
 #include <qt/walletmodel.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <functional>

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -4,12 +4,12 @@
 
 #include <qt/test/rpcnestedtests.h>
 
+#include <common/system.h>
 #include <interfaces/node.h>
-#include <rpc/server.h>
 #include <qt/rpcconsole.h>
+#include <rpc/server.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
-#include <util/system.h>
 
 #include <QTest>
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -13,12 +13,12 @@
 #include <qt/paymentserver.h>
 #include <qt/transactionrecord.h>
 
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <policy/policy.h>
-#include <util/system.h>
 #include <validation.h>
 #include <wallet/types.h>
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -8,6 +8,7 @@
 #include <blockfilter.h>
 #include <chain.h>
 #include <chainparams.h>
+#include <common/system.h>
 #include <core_io.h>
 #include <httpserver.h>
 #include <index/blockfilterindex.h>
@@ -25,7 +26,6 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <util/check.h>
-#include <util/system.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1123,8 +1123,7 @@ static RPCHelpMan verifychain()
     LOCK(cs_main);
 
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    return CVerifyDB().VerifyDB(
-               active_chainstate, chainman.GetParams().GetConsensus(), active_chainstate.CoinsTip(), check_level, check_depth) == VerifyDBResult::SUCCESS;
+    return CVerifyDB(chainman.GetShowProgressCb()).VerifyDB(active_chainstate, chainman.GetParams().GetConsensus(), active_chainstate.CoinsTip(), check_level, check_depth) == VerifyDBResult::SUCCESS;
 },
     };
 }

--- a/src/rpc/external_signer.cpp
+++ b/src/rpc/external_signer.cpp
@@ -3,12 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
+#include <common/system.h>
 #include <external_signer.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -5,6 +5,7 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
@@ -32,7 +33,6 @@
 #include <univalue.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/system.h>
 #include <httpserver.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
@@ -21,7 +22,6 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/syscall_sandbox.h>
-#include <util/system.h>
 
 #include <stdint.h>
 #ifdef HAVE_MALLOC_INFO

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -6,13 +6,13 @@
 #include <rpc/server.h>
 
 #include <common/args.h>
+#include <common/system.h>
 #include <logging.h>
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <boost/signals2/signal.hpp>

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -5,13 +5,13 @@
 #include <rpc/server_util.h>
 
 #include <common/args.h>
+#include <common/system.h>
 #include <net_processing.h>
 #include <node/context.h>
 #include <policy/fees.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <txmempool.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <any>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -5,11 +5,11 @@
 
 #include <script/sigcache.h>
 
+#include <common/system.h>
 #include <logging.h>
 #include <pubkey.h>
 #include <random.h>
 #include <uint256.h>
-#include <util/system.h>
 
 #include <cuckoocache.h>
 

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -10,7 +10,6 @@
 #endif
 
 #include <logging.h>
-#include <node/interface_ui.h>
 #include <util/tokenpipe.h>
 #include <warnings.h>
 
@@ -20,14 +19,14 @@
 #include <condition_variable>
 #endif
 
-bool AbortNode(const std::string& strMessage, bilingual_str user_message)
+bool AbortNode(const std::string& strMessage, const std::function<void(const bilingual_str& user_message)>& init_error, bilingual_str user_message)
 {
     SetMiscWarning(Untranslated(strMessage));
     LogPrintf("*** %s\n", strMessage);
     if (user_message.empty()) {
         user_message = _("A fatal internal error occurred, see debug.log for details");
     }
-    InitError(user_message);
+    init_error(user_message);
     StartShutdown();
     return false;
 }

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -9,7 +9,7 @@
 #include <util/translation.h> // For bilingual_str
 
 /** Abort with a message */
-bool AbortNode(const std::string& strMessage, bilingual_str user_message = bilingual_str{});
+bool AbortNode(const std::string& strMessage, const std::function<void(const bilingual_str& user_message)>& init_error, bilingual_str user_message = bilingual_str{});
 
 /** Initialize shutdown state. This must be called before using either StartShutdown(),
  * AbortShutdown() or WaitForShutdown(). Calling ShutdownRequested() is always safe.

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <vector>
 
+#include <common/system.h>
 #include <consensus/merkle.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
@@ -22,7 +23,6 @@
 #include <streams.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 static constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2};
 

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <support/lockedpool.h>
-#include <util/system.h>
 
 #include <limits>
 #include <memory>

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <node/blockstorage.h>
+#include <node/chainstatemanager_notifications.h>
 #include <node/context.h>
 #include <util/chaintype.h>
 #include <validation.h>
@@ -11,8 +12,9 @@
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
 
-using node::BlockManager;
 using node::BLOCK_SERIALIZATION_HEADER_SIZE;
+using node::BlockManager;
+using node::DefaultChainstateManagerNotifications;
 using node::MAX_BLOCKFILE_SIZE;
 
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
@@ -24,6 +26,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
     const BlockManager::Options blockman_opts{
         .chainparams = *params,
         .blocks_dir = m_args.GetBlocksDirPath(),
+        .init_error_callback = DefaultChainstateManagerNotifications().init_error,
     };
     BlockManager blockman{blockman_opts};
     CChain chain {};

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -5,6 +5,7 @@
 #include <common/bloom.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <key.h>
 #include <key_io.h>
 #include <merkleblock.h>
@@ -16,7 +17,6 @@
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <vector>
 

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -4,6 +4,7 @@
 
 #include <arith_uint256.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <compressor.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
@@ -32,7 +33,6 @@
 #include <util/overflow.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <version.h>
 
 #include <cassert>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -5,6 +5,7 @@
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <netbase.h>
 #include <outputtype.h>
@@ -24,7 +25,6 @@
 #include <util/settings.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <cassert>

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <key.h>
 
+#include <common/system.h>
 #include <key_io.h>
 #include <streams.h>
 #include <test/util/random.h>
@@ -11,7 +12,6 @@
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <policy/policy.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
@@ -15,7 +16,6 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <validation.h>
 #include <versionbits.h>

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) 2021-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <common/system.h>
 #include <policy/rbf.h>
 #include <random.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -5,6 +5,7 @@
 #include <test/data/script_tests.json.h>
 #include <test/data/bip341_wallet_vectors.json.h>
 
+#include <common/system.h>
 #include <core_io.h>
 #include <key.h>
 #include <rpc/util.h>
@@ -20,7 +21,6 @@
 #include <test/util/transaction_utils.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <hash.h>
@@ -14,7 +15,6 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <version.h>
 
 #include <iostream>

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <compat/compat.h>
 #include <test/util/setup_common.h>
 #include <util/sock.h>
-#include <util/system.h>
 #include <util/threadinterrupt.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -9,6 +9,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <chainparams.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <consensus/consensus.h>
 #include <consensus/params.h>
@@ -46,7 +47,6 @@
 #include <util/chaintype.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadnames.h>
 #include <util/time.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -22,6 +22,7 @@
 #include <net_processing.h>
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
+#include <node/chainstatemanager_notifications.h>
 #include <node/context.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
@@ -64,6 +65,7 @@ using node::ApplyArgsManOptions;
 using node::BlockAssembler;
 using node::BlockManager;
 using node::CalculateCacheSizes;
+using node::DefaultChainstateManagerNotifications;
 using node::LoadChainstate;
 using node::RegenerateCommitments;
 using node::VerifyLoadedChainstate;
@@ -186,6 +188,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, const std::vecto
         .datadir = m_args.GetDataDirNet(),
         .adjusted_time_callback = GetAdjustedTime,
         .check_block_index = true,
+        .notification_callbacks = DefaultChainstateManagerNotifications(),
     };
     const BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -193,6 +193,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, const std::vecto
     const BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = m_args.GetBlocksDirPath(),
+        .init_error_callback = chainman_opts.notification_callbacks.init_error,
     };
     m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
     m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(DBParams{

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1687,7 +1687,7 @@ BOOST_AUTO_TEST_CASE(message_hash)
 
 BOOST_AUTO_TEST_CASE(remove_prefix)
 {
-    BOOST_CHECK_EQUAL(RemovePrefix("./util/system.h", "./"), "util/system.h");
+    BOOST_CHECK_EQUAL(RemovePrefix("./common/system.h", "./"), "common/system.h");
     BOOST_CHECK_EQUAL(RemovePrefixView("foo", "foo"), "");
     BOOST_CHECK_EQUAL(RemovePrefix("foo", "fo"), "o");
     BOOST_CHECK_EQUAL(RemovePrefixView("foo", "f"), "oo");

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -388,6 +388,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             const BlockManager::Options blockman_opts{
                 .chainparams = chainman_opts.chainparams,
                 .blocks_dir = m_args.GetBlocksDirPath(),
+                .init_error_callback = chainman_opts.notification_callbacks.init_error,
             };
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -4,6 +4,7 @@
 //
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <node/chainstatemanager_notifications.h>
 #include <node/utxo_snapshot.h>
 #include <random.h>
 #include <rpc/blockchain.h>
@@ -23,6 +24,7 @@
 #include <boost/test/unit_test.hpp>
 
 using node::BlockManager;
+using node::DefaultChainstateManagerNotifications;
 using node::SnapshotMetadata;
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, ChainTestingSetup)
@@ -381,6 +383,7 @@ struct SnapshotTestSetup : TestChain100Setup {
                 .chainparams = ::Params(),
                 .datadir = m_args.GetDataDirNet(),
                 .adjusted_time_callback = GetAdjustedTime,
+                .notification_callbacks = DefaultChainstateManagerNotifications(),
             };
             const BlockManager::Options blockman_opts{
                 .chainparams = chainman_opts.chainparams,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -7,6 +7,7 @@
 
 #include <chain.h>
 #include <coins.h>
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
@@ -19,7 +20,6 @@
 #include <util/moneystr.h>
 #include <util/overflow.h>
 #include <util/result.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/trace.h>
 #include <util/translation.h>

--- a/src/util/batchpriority.cpp
+++ b/src/util/batchpriority.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <logging.h>
+#include <util/syserror.h>
+
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+#include <pthread.h>
+#include <pthread_np.h>
+#endif
+
+#ifndef WIN32
+#include <sched.h>
+#endif
+
+void ScheduleBatchPriority()
+{
+#ifdef SCHED_BATCH
+    const static sched_param param{};
+    const int rc = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param);
+    if (rc != 0) {
+        LogPrintf("Failed to pthread_setschedparam: %s\n", SysErrorString(rc));
+    }
+#endif
+}

--- a/src/util/batchpriority.h
+++ b/src/util/batchpriority.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_BATCHPRIORITY_H
+#define BITCOIN_UTIL_BATCHPRIORITY_H
+
+/**
+ * On platforms that support it, tell the kernel the calling thread is
+ * CPU-intensive and non-interactive. See SCHED_BATCH in sched(7) for details.
+ *
+ */
+void ScheduleBatchPriority();
+
+#endif // BITCOIN_UTIL_BATCHPRIORITY_H

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <tinyformat.h>
 #include <util/sock.h>
 #include <util/syserror.h>
-#include <util/system.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -7,16 +7,9 @@
 
 #include <logging.h>
 #include <util/string.h>
-#include <util/syserror.h>
 #include <util/time.h>
 
-#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
-#include <pthread.h>
-#include <pthread_np.h>
-#endif
-
 #ifndef WIN32
-#include <sched.h>
 #include <sys/stat.h>
 #else
 #include <codecvt>
@@ -111,15 +104,4 @@ int GetNumCores()
 int64_t GetStartupTime()
 {
     return nStartupTime;
-}
-
-void ScheduleBatchPriority()
-{
-#ifdef SCHED_BATCH
-    const static sched_param param{};
-    const int rc = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param);
-    if (rc != 0) {
-        LogPrintf("Failed to pthread_setschedparam: %s\n", SysErrorString(rc));
-    }
-#endif
 }

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -36,13 +36,6 @@ void runCommand(const std::string& strCommand);
  */
 int GetNumCores();
 
-/**
- * On platforms that support it, tell the kernel the calling thread is
- * CPU-intensive and non-interactive. See SCHED_BATCH in sched(7) for details.
- *
- */
-void ScheduleBatchPriority();
-
 namespace util {
 
 //! Simplification of std insertion

--- a/src/validation.h
+++ b/src/validation.h
@@ -103,7 +103,7 @@ void StopScriptCheckWorkerThreads();
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
-bool AbortNode(BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage = bilingual_str{});
+bool AbortNode(BlockValidationState& state, const std::string& strMessage, const std::function<void(const bilingual_str& user_message)>& init_error, const bilingual_str& userMessage = bilingual_str{});
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
 double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pindex);
@@ -966,6 +966,7 @@ public:
     void ShowProgress(const std::string& title, int nProgress, bool resume_possible) const;
     std::function<void(const std::string&, int, bool)> GetShowProgressCb() const;
     void DoWarning(const bilingual_str& warning) const;
+    const std::function<void(const bilingual_str&)>& GetInitErrorCb() const;
 
     /**
      * Alias for ::cs_main.
@@ -1051,9 +1052,7 @@ public:
     //! deletion and continue using the snapshot chainstate as active.
     //! Otherwise, revert to using the ibd chainstate and shutdown.
     SnapshotCompletionResult MaybeCompleteSnapshotValidation(
-        std::function<void(bilingual_str)> shutdown_fnc =
-            [](bilingual_str msg) { AbortNode(msg.original, msg); })
-        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+        std::function<void(bilingual_str)> shutdown_fnc) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! The most-work chain.
     Chainstate& ActiveChainstate() const;

--- a/src/validation.h
+++ b/src/validation.h
@@ -965,6 +965,7 @@ public:
     void NotifyHeaderTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) const;
     void ShowProgress(const std::string& title, int nProgress, bool resume_possible) const;
     std::function<void(const std::string&, int, bool)> GetShowProgressCb() const;
+    void DoWarning(const bilingual_str& warning) const;
 
     /**
      * Alias for ::cs_main.

--- a/src/validation.h
+++ b/src/validation.h
@@ -947,6 +947,7 @@ private:
 
 public:
     using Options = kernel::ChainstateManagerOpts;
+    using NotificationCallbacks = kernel::ChainstateManagerNotificationCallbacks;
 
     explicit ChainstateManager(Options options, node::BlockManager::Options blockman_options);
 
@@ -955,6 +956,8 @@ public:
     bool ShouldCheckBlockIndex() const { return *Assert(m_options.check_block_index); }
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
+
+    void NotifyBlockTip(SynchronizationState state, CBlockIndex* index) const;
 
     /**
      * Alias for ::cs_main.

--- a/src/validation.h
+++ b/src/validation.h
@@ -958,6 +958,7 @@ public:
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
 
     void NotifyBlockTip(SynchronizationState state, CBlockIndex* index) const;
+    void NotifyHeaderTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) const;
 
     /**
      * Alias for ::cs_main.

--- a/src/validation.h
+++ b/src/validation.h
@@ -365,8 +365,12 @@ enum class VerifyDBResult {
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB {
+private:
+    const std::function<void(const std::string& title, int nProgress, bool resume_possible)> m_show_progress;
+    void ShowProgress(const std::string& title, int nProgress, bool resume_possible) const;
+
 public:
-    CVerifyDB();
+    explicit CVerifyDB(std::function<void(const std::string& title, int nProgress, bool resume_possible)> show_progress);
     ~CVerifyDB();
     [[nodiscard]] VerifyDBResult VerifyDB(
         Chainstate& chainstate,
@@ -959,6 +963,8 @@ public:
 
     void NotifyBlockTip(SynchronizationState state, CBlockIndex* index) const;
     void NotifyHeaderTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) const;
+    void ShowProgress(const std::string& title, int nProgress, bool resume_possible) const;
+    std::function<void(const std::string&, int, bool)> GetShowProgressCb() const;
 
     /**
      * Alias for ::cs_main.

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -7,10 +7,10 @@
 #define BITCOIN_WALLET_BDB_H
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <serialize.h>
 #include <streams.h>
 #include <util/fs.h>
-#include <util/system.h>
 #include <wallet/db.h>
 
 #include <atomic>

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -4,13 +4,13 @@
 
 #include <wallet/coinselection.h>
 
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <logging.h>
 #include <policy/feerate.h>
 #include <util/check.h>
 #include <util/moneystr.h>
-#include <util/system.h>
 
 #include <numeric>
 #include <optional>

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_WALLET_COINSELECTION_H
 #define BITCOIN_WALLET_COINSELECTION_H
 
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <random.h>
-#include <util/system.h>
 #include <util/check.h>
 #include <util/result.h>
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/crypter.h>
 
+#include <common/system.h>
 #include <crypto/aes.h>
 #include <crypto/sha512.h>
-#include <util/system.h>
 
 #include <vector>
 

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -4,8 +4,8 @@
 
 #include <chainparams.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <external_signer.h>
-#include <util/system.h>
 #include <wallet/external_signer_scriptpubkeyman.h>
 
 #include <iostream>

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/rpc/util.h>
 
+#include <common/system.h>
 #include <common/url.h>
 #include <rpc/util.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <common/args.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
@@ -15,7 +16,6 @@
 #include <util/fees.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
-#include <util/system.h>
 #include <util/trace.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -5,13 +5,13 @@
 
 #include <wallet/walletdb.h>
 
+#include <common/system.h>
 #include <key_io.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
 #include <util/bip32.h>
 #include <util/fs.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 #ifdef USE_BDB

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -5,9 +5,9 @@
 
 #include <warnings.h>
 
+#include <common/system.h>
 #include <sync.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <vector>


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/27587 https://github.com/bitcoin/bitcoin/projects/18 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel". 

It removes the kernel library's reliance on `util/system` and `interface_ui`. `util/system` contains networking and shell-related code that should not be part of the kernel library. The following pull requests prepared `util/system` for this final step: https://github.com/bitcoin/bitcoin/pull/27419 https://github.com/bitcoin/bitcoin/pull/27254 https://github.com/bitcoin/bitcoin/pull/27238 .

`interface_ui` defines functions for a more general node interface and has a dependency on `boost/signals2`. After applying the patches from this pull request, the kernel's reliance on boost is down to `boost::multiindex`.

The approach implemented here introduces some indirection, which makes the code a bit harder to read. Any suggestions for improving or reworking this pull request to make it more concise, or even reworking it into a more proper interface, are welcome.