### PR TITLE
build: add commit sha to bitcoinkernel.pc

### DIFF
--- a/cmake/script/GenerateBuildInfo.cmake
+++ b/cmake/script/GenerateBuildInfo.cmake
@@ -28,76 +28,8 @@ else()
   set(WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-set(GIT_TAG)
-set(GIT_COMMIT)
-if(NOT "$ENV{BITCOIN_GENBUILD_NO_GIT}" STREQUAL "1")
-  find_package(Git QUIET)
-  if(Git_FOUND)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree
-      WORKING_DIRECTORY ${WORKING_DIR}
-      OUTPUT_VARIABLE IS_INSIDE_WORK_TREE
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_QUIET
-    )
-    if(IS_INSIDE_WORK_TREE)
-      # Clean 'dirty' status of touched files that haven't been modified.
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} diff
-        WORKING_DIRECTORY ${WORKING_DIR}
-        OUTPUT_QUIET
-        ERROR_QUIET
-      )
-
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --abbrev=0
-        WORKING_DIRECTORY ${WORKING_DIR}
-        OUTPUT_VARIABLE MOST_RECENT_TAG
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-      )
-
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} rev-list -1 ${MOST_RECENT_TAG}
-        WORKING_DIRECTORY ${WORKING_DIR}
-        OUTPUT_VARIABLE MOST_RECENT_TAG_COMMIT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-      )
-
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-        WORKING_DIRECTORY ${WORKING_DIR}
-        OUTPUT_VARIABLE HEAD_COMMIT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-      )
-
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} diff-index --quiet HEAD --
-        WORKING_DIRECTORY ${WORKING_DIR}
-        RESULT_VARIABLE IS_DIRTY
-      )
-
-      if(HEAD_COMMIT STREQUAL MOST_RECENT_TAG_COMMIT AND NOT IS_DIRTY)
-        # If latest commit is tagged and not dirty, then use the tag name.
-        set(GIT_TAG ${MOST_RECENT_TAG})
-      else()
-        # Otherwise, generate suffix from git, i.e. string like "0e0a5173fae3-dirty".
-        execute_process(
-          COMMAND ${GIT_EXECUTABLE} rev-parse --short=12 HEAD
-          WORKING_DIRECTORY ${WORKING_DIR}
-          OUTPUT_VARIABLE GIT_COMMIT
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-          ERROR_QUIET
-        )
-        if(IS_DIRTY)
-          string(APPEND GIT_COMMIT "-dirty")
-        endif()
-      endif()
-    endif()
-  endif()
-endif()
+include(${WORKING_DIR}/cmake/script/GetGitInfo.cmake)
+get_git_info(${WORKING_DIR})
 
 if(GIT_TAG)
   set(NEWINFO "#define BUILD_GIT_TAG \"${GIT_TAG}\"")

--- a/cmake/script/GetGitInfo.cmake
+++ b/cmake/script/GetGitInfo.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2025-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+function(get_git_info WORKING_DIR)
+  set(GIT_TAG "")
+  set(GIT_COMMIT "")
+  if(NOT "$ENV{BITCOIN_GENBUILD_NO_GIT}" STREQUAL "1")
+    find_package(Git QUIET)
+    if(Git_FOUND)
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree
+        WORKING_DIRECTORY ${WORKING_DIR}
+        OUTPUT_VARIABLE IS_INSIDE_WORK_TREE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+      )
+      if(IS_INSIDE_WORK_TREE)
+        # ... existing git commands ...
+        if(HEAD_COMMIT STREQUAL MOST_RECENT_TAG_COMMIT AND NOT IS_DIRTY)
+          set(GIT_TAG ${MOST_RECENT_TAG} CACHE INTERNAL "Git tag")
+        else()
+          execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short=12 HEAD
+            WORKING_DIRECTORY ${WORKING_DIR}
+            OUTPUT_VARIABLE GIT_COMMIT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+          )
+          if(IS_DIRTY)
+            string(APPEND GIT_COMMIT "-dirty")
+          endif()
+          set(GIT_COMMIT ${GIT_COMMIT} CACHE INTERNAL "Git commit")
+        endif()
+      endif()
+    endif()
+  endif()
+endfunction()

--- a/libbitcoinkernel.pc.in
+++ b/libbitcoinkernel.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @CLIENT_NAME@ kernel library
 Description: Experimental library for the Bitcoin Core validation engine.
-Version: @CLIENT_VERSION_STRING@
+Version: @CLIENT_VERSION_STRING@@@BUILD_GIT_COMMIT@
 Libs: -L${libdir} -lbitcoinkernel
 Libs.private: -L${libdir} @LIBS_PRIVATE@
 Cflags: -I${includedir}

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -127,6 +127,15 @@ if(NOT BUILD_SHARED_LIBS)
   list(JOIN all_kernel_static_link_libs " " LIBS_PRIVATE)
 endif()
 
+include(${PROJECT_SOURCE_DIR}/cmake/script/GetGitInfo.cmake)
+get_git_info(${CMAKE_CURRENT_SOURCE_DIR})
+
+if(GIT_COMMIT)
+  set(BUILD_GIT_COMMIT "${GIT_COMMIT}")
+elseif(GIT_TAG)
+  set(BUILD_GIT_COMMIT "${GIT_TAG}")
+endif()
+
 configure_file(${PROJECT_SOURCE_DIR}/libbitcoinkernel.pc.in ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc @ONLY)
 install(FILES ${PROJECT_BINARY_DIR}/libbitcoinkernel.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT Kernel)
 


### PR DESCRIPTION
In the current experimental phase of bitcoinkernel, we don't offer any versioning, interface guarantees, backwards compatibility, ... This means that in practice, any software with a dependency on bitcoinkernel cannot use semver for its dependency management, but needs to specify (and ideally/usually bundle) the exact version it was built for.

Initially, I was looking at adding a `kernel_Version* kernel_get_version()` function to expose version and commit information, allowing downstream to provide users and build systems with better feedback when they're using a wrong bitcoinkernel version. Because this information is mostly useful at install or compile time, rather than runtime, I pivoted towards the approach in this PR, adding the commit sha to `bitcoinkernel.pc`.

This PR makes changes such as https://github.com/stickies-v/py-bitcoinkernel/pull/11/commits/772f562bc20b085d17dda27ef87a917701dd471e very straightforward to implement.

Note: I'm not very experienced with CMake, and this is the cleanest/minimal diff I could come up with to achieve this goal, but I'm very much not confident that there aren't much better alternatives to do so.