### PR TITLE
kernel: merge all options into ChainstateManagerOptions; disallow invalid wiping settings

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -164,13 +164,11 @@ int main(int argc, char* argv[])
     Context context{options};
     assert(context);
 
-    ChainstateManagerOptions chainman_opts{context, abs_datadir.string()};
+    ChainstateManagerOptions chainman_opts{context, abs_datadir.string(), (abs_datadir / "blocks").string()};
     assert(chainman_opts);
     chainman_opts.SetWorkerThreads(4);
-    BlockManagerOptions blockman_opts{context, abs_datadir.string(), (abs_datadir / "blocks").string()};
-    assert(blockman_opts);
 
-    auto chainman{std::make_unique<ChainMan>(context, chainman_opts, blockman_opts)};
+    auto chainman{std::make_unique<ChainMan>(context, chainman_opts)};
     if (!*chainman) {
         return 1;
     }

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -169,9 +169,8 @@ int main(int argc, char* argv[])
     chainman_opts.SetWorkerThreads(4);
     BlockManagerOptions blockman_opts{context, abs_datadir.string(), (abs_datadir / "blocks").string()};
     assert(blockman_opts);
-    ChainstateLoadOptions chainstate_load_opts{};
 
-    auto chainman{std::make_unique<ChainMan>(context, chainman_opts, blockman_opts, chainstate_load_opts)};
+    auto chainman{std::make_unique<ChainMan>(context, chainman_opts, blockman_opts)};
     if (!*chainman) {
         return 1;
     }

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -769,12 +769,18 @@ kernel_ChainstateManagerOptions* kernel_chainstate_manager_options_create(
     }
 }
 
-void kernel_chainstate_manager_options_set_wipe_chainstate_db(
+bool kernel_chainstate_manager_options_set_wipe_chainstate_db(
     kernel_ChainstateManagerOptions* chainstate_manager_opts_,
     bool wipe_chainstate_db)
 {
     auto chainstate_load_opts{cast_chainstate_load_options(chainstate_manager_opts_)};
+    auto block_manager_opts{cast_block_manager_options(chainstate_manager_opts_)};
+    if (block_manager_opts->block_tree_db_params.wipe_data && !wipe_chainstate_db) {
+        LogWarning("Wiping the block tree db without also wiping the chainstate db is currently unsupported.");
+        return false;
+    }
     chainstate_load_opts->wipe_chainstate_db = wipe_chainstate_db;
+    return true;
 }
 
 void kernel_chainstate_manager_options_set_chainstate_db_in_memory(
@@ -798,12 +804,18 @@ void kernel_chainstate_manager_options_destroy(kernel_ChainstateManagerOptions* 
     }
 }
 
-void kernel_chainstate_manager_options_set_wipe_block_tree_db(
+bool kernel_chainstate_manager_options_set_wipe_block_tree_db(
     kernel_ChainstateManagerOptions* chainstate_manager_opts_,
     bool wipe_block_tree_db)
 {
     auto block_manager_options{cast_block_manager_options(chainstate_manager_opts_)};
+    auto chainstate_load_opts{cast_chainstate_load_options(chainstate_manager_opts_)};
+    if (wipe_block_tree_db && !chainstate_load_opts->wipe_chainstate_db) {
+        LogWarning("Wiping the block tree db without also wiping the chainstate db is currently unsupported.");
+        return false;
+    }
     block_manager_options->block_tree_db_params.wipe_data = wipe_block_tree_db;
+    return true;
 }
 
 void kernel_chainstate_manager_options_set_block_tree_db_in_memory(

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -207,14 +207,6 @@ typedef struct kernel_BlockManagerOptions kernel_BlockManagerOptions;
 typedef struct kernel_ChainstateManager kernel_ChainstateManager;
 
 /**
- * Opaque data structure for holding parameters used for loading the chainstate
- * of a chainstate manager.
- *
- * Is initialized with default parameters.
- */
-typedef struct kernel_ChainstateLoadOptions kernel_ChainstateLoadOptions;
-
-/**
  * Opaque data structure for holding a block.
  */
 typedef struct kernel_Block kernel_Block;
@@ -782,6 +774,26 @@ BITCOINKERNEL_API kernel_ChainstateManagerOptions* BITCOINKERNEL_WARN_UNUSED_RES
 ) BITCOINKERNEL_ARG_NONNULL(1, 2);
 
 /**
+ * @brief Sets wipe chainstate db in the chainstate manager options.
+ *
+ * @param[in] chainstate_manager_options Non-null, options to be set.
+ * @param[in] wipe_chainstate_db      Set wipe chainstate db.
+ */
+BITCOINKERNEL_API void kernel_chainstate_manager_options_set_wipe_chainstate_db(
+    kernel_ChainstateManagerOptions* chainstate_manager_options,
+    bool wipe_chainstate_db) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Sets chainstate db in memory in the chainstate manager options.
+ *
+ * @param[in] chainstate_manager_options Non-null, options to be set.
+ * @param[in] chainstate_db_in_memory Set chainstate db in memory.
+ */
+BITCOINKERNEL_API void kernel_chainstate_manager_options_set_chainstate_db_in_memory(
+    kernel_ChainstateManagerOptions* chainstate_manager_options,
+    bool chainstate_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
  * @brief Set the number of available worker threads used during validation.
  *
  * @param[in] chainstate_manager_options Non-null, options to be set.
@@ -857,45 +869,6 @@ BITCOINKERNEL_API void kernel_block_manager_options_destroy(kernel_BlockManagerO
 
 ///@}
 
-/** @name ChainstateLoadOptions
- * Functions for working with chainstate load options.
- */
-///@{
-
-/**
- * Create options for loading the chainstate.
- */
-BITCOINKERNEL_API kernel_ChainstateLoadOptions* BITCOINKERNEL_WARN_UNUSED_RESULT kernel_chainstate_load_options_create();
-
-/**
- * @brief Sets wipe chainstate db in the chainstate load options.
- *
- * @param[in] chainstate_load_options Non-null, created by @ref kernel_chainstate_load_options_create.
- * @param[in] wipe_chainstate_db      Set wipe chainstate db.
- */
-BITCOINKERNEL_API void kernel_chainstate_load_options_set_wipe_chainstate_db(
-    kernel_ChainstateLoadOptions* chainstate_load_options,
-    bool wipe_chainstate_db
-) BITCOINKERNEL_ARG_NONNULL(1);
-
-/**
- * @brief Sets chainstate db in memory in the chainstate load options.
- *
- * @param[in] chainstate_load_options Non-null, created by @ref kernel_chainstate_load_options_create.
- * @param[in] chainstate_db_in_memory Set chainstate db in memory.
- */
-BITCOINKERNEL_API void kernel_chainstate_load_options_set_chainstate_db_in_memory(
-    kernel_ChainstateLoadOptions* chainstate_load_options,
-    bool chainstate_db_in_memory
-) BITCOINKERNEL_ARG_NONNULL(1);
-
-/**
- * Destroy the chainstate load options
- */
-BITCOINKERNEL_API void kernel_chainstate_load_options_destroy(kernel_ChainstateLoadOptions* chainstate_load_options);
-
-///@}
-
 /** @name ChainstateManager
  * Functions for chainstate management.
  */
@@ -917,9 +890,7 @@ BITCOINKERNEL_API void kernel_chainstate_load_options_destroy(kernel_ChainstateL
 BITCOINKERNEL_API kernel_ChainstateManager* BITCOINKERNEL_WARN_UNUSED_RESULT kernel_chainstate_manager_create(
     const kernel_Context* context,
     const kernel_ChainstateManagerOptions* chainstate_manager_options,
-    const kernel_BlockManagerOptions* block_manager_options,
-    const kernel_ChainstateLoadOptions* chainstate_load_options
-) BITCOINKERNEL_ARG_NONNULL(1, 2, 3);
+    const kernel_BlockManagerOptions* block_manager_options) BITCOINKERNEL_ARG_NONNULL(1, 2, 3);
 
 /**
  * @brief May be called after kernel_chainstate_manager_load_chainstate to

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -184,15 +184,6 @@ typedef struct kernel_BlockIndex kernel_BlockIndex;
 typedef struct kernel_ChainstateManagerOptions kernel_ChainstateManagerOptions;
 
 /**
- * Opaque data structure for holding options for creating a new chainstate
- * manager.
- *
- * The chainstate manager has an internal block manager that takes its own set
- * of parameters. It is initialized with default options.
- */
-typedef struct kernel_BlockManagerOptions kernel_BlockManagerOptions;
-
-/**
  * Opaque data structure for holding a chainstate manager.
  *
  * The chainstate manager is the central object for doing validation tasks as
@@ -770,8 +761,30 @@ BITCOINKERNEL_API void kernel_context_destroy(kernel_Context* context);
 BITCOINKERNEL_API kernel_ChainstateManagerOptions* BITCOINKERNEL_WARN_UNUSED_RESULT kernel_chainstate_manager_options_create(
     const kernel_Context* context,
     const char* data_directory,
-    size_t data_directory_len
-) BITCOINKERNEL_ARG_NONNULL(1, 2);
+    size_t data_directory_len,
+    const char* blocks_directory,
+    size_t blocks_directory_len) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Sets wipe block tree db in the chainstate manager options.
+ *
+ * @param[in] chainstate_manager_options Non-null, options to be set.
+ * @param[in] wipe_block_tree_db    Set wipe block tree db.
+ */
+BITCOINKERNEL_API void kernel_chainstate_manager_options_set_wipe_block_tree_db(
+    kernel_ChainstateManagerOptions* chainstate_manager_options,
+    bool wipe_block_tree_db) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Sets block tree db in memory in the chainstate manager options.
+ *
+ * @param[in] chainstate_manager_options Non-null, options to be set.
+ * @param[in] block_tree_db_in_memory Set block tree db in memory.
+ */
+
+BITCOINKERNEL_API void kernel_chainstate_manager_options_set_block_tree_db_in_memory(
+    kernel_ChainstateManagerOptions* chainstate_manager_options,
+    bool block_tree_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
 
 /**
  * @brief Sets wipe chainstate db in the chainstate manager options.
@@ -811,64 +824,6 @@ BITCOINKERNEL_API void kernel_chainstate_manager_options_set_worker_threads_num(
  */
 BITCOINKERNEL_API void kernel_chainstate_manager_options_destroy(kernel_ChainstateManagerOptions* chainstate_manager_options);
 
-///@}
-
-/** @name BlockManagerOptions
- * Functions for working with block manager options.
- */
-///@{
-
-/**
- * @brief Create options for the block manager. The block manager is used
- * internally by the chainstate manager for block storage and indexing.
- *
- * @param[in] context          Non-null, the created options will associate with this kernel context
- *                             for the duration of their lifetime. The same context needs to be used
- *                             when instantiating the chainstate manager.
- * @param[in] data_directory   Non-null, path string of the directory containing the chainstate data.
- *                             This is usually the same as the data directory used for the chainstate
- *                             manager options. If the directory does not exist yet, it will be created.
- * @param[in] blocks_directory Non-null, path string of the directory containing the block data. If
- *                             the directory does not exist yet, it will be created.
- * @return                     The allocated block manager options, or null on error.
- */
-BITCOINKERNEL_API kernel_BlockManagerOptions* BITCOINKERNEL_WARN_UNUSED_RESULT kernel_block_manager_options_create(
-    const kernel_Context* context,
-    const char* data_directory,
-    size_t data_directory_len,
-    const char* blocks_directory,
-    size_t blocks_directory_len
-) BITCOINKERNEL_ARG_NONNULL(1, 2);
-
-/**
- * @brief Sets wipe block tree db in the block manager options.
- *
- * @param[in] block_manager_options Non-null, created by @ref kernel_block_manager_options_create.
- * @param[in] wipe_block_tree_db    Set wipe block tree db.
- */
-BITCOINKERNEL_API void kernel_block_manager_options_set_wipe_block_tree_db(
-    kernel_BlockManagerOptions* block_manager_options,
-    bool wipe_block_tree_db
-) BITCOINKERNEL_ARG_NONNULL(1);
-
-/**
- * @brief Sets block tree db in memory in the block manager options.
- *
- * @param[in] block_manager_options   Non-null, created by @ref kernel_block_manager_options_create.
- * @param[in] block_tree_db_in_memory Set block tree db in memory.
- */
-BITCOINKERNEL_API void kernel_block_manager_options_set_block_tree_db_in_memory(
-    kernel_BlockManagerOptions* block_manager_options,
-    bool block_tree_db_in_memory
-) BITCOINKERNEL_ARG_NONNULL(1);
-
-/**
- * Destroy the block manager options.
- */
-BITCOINKERNEL_API void kernel_block_manager_options_destroy(kernel_BlockManagerOptions* block_manager_options);
-
-///@}
-
 /** @name ChainstateManager
  * Functions for chainstate management.
  */
@@ -881,7 +836,6 @@ BITCOINKERNEL_API void kernel_block_manager_options_destroy(kernel_BlockManagerO
  * the passed in context also remains in memory.
  *
  * @param[in] chainstate_manager_options Non-null, created by @ref kernel_chainstate_manager_options_create.
- * @param[in] block_manager_options      Non-null, created by @ref kernel_block_manager_options_create.
  * @param[in] context                    Non-null, the created chainstate manager will associate with this
  *                                       kernel context for the duration of its lifetime. The same context
  *                                       needs to be used for later interactions with the chainstate manager.
@@ -889,8 +843,7 @@ BITCOINKERNEL_API void kernel_block_manager_options_destroy(kernel_BlockManagerO
  */
 BITCOINKERNEL_API kernel_ChainstateManager* BITCOINKERNEL_WARN_UNUSED_RESULT kernel_chainstate_manager_create(
     const kernel_Context* context,
-    const kernel_ChainstateManagerOptions* chainstate_manager_options,
-    const kernel_BlockManagerOptions* block_manager_options) BITCOINKERNEL_ARG_NONNULL(1, 2, 3);
+    const kernel_ChainstateManagerOptions* chainstate_manager_options) BITCOINKERNEL_ARG_NONNULL(1, 2);
 
 /**
  * @brief May be called after kernel_chainstate_manager_load_chainstate to

--- a/src/kernel/bitcoinkernel.h
+++ b/src/kernel/bitcoinkernel.h
@@ -767,11 +767,16 @@ BITCOINKERNEL_API kernel_ChainstateManagerOptions* BITCOINKERNEL_WARN_UNUSED_RES
 
 /**
  * @brief Sets wipe block tree db in the chainstate manager options.
+ *        If wipe_chainstate_db is set to False, this option may not be
+ *        set to True.
  *
  * @param[in] chainstate_manager_options Non-null, options to be set.
  * @param[in] wipe_block_tree_db    Set wipe block tree db.
+ *
+ * @return  True if the set was successful, False if the set failed
+ *          due to wipe_chainstate_db incompatibility.
  */
-BITCOINKERNEL_API void kernel_chainstate_manager_options_set_wipe_block_tree_db(
+BITCOINKERNEL_API bool BITCOINKERNEL_WARN_UNUSED_RESULT kernel_chainstate_manager_options_set_wipe_block_tree_db(
     kernel_ChainstateManagerOptions* chainstate_manager_options,
     bool wipe_block_tree_db) BITCOINKERNEL_ARG_NONNULL(1);
 
@@ -788,11 +793,15 @@ BITCOINKERNEL_API void kernel_chainstate_manager_options_set_block_tree_db_in_me
 
 /**
  * @brief Sets wipe chainstate db in the chainstate manager options.
+ *        If wipe_block_tree_db is set to True, this must be set to True.
  *
  * @param[in] chainstate_manager_options Non-null, options to be set.
  * @param[in] wipe_chainstate_db      Set wipe chainstate db.
+ *
+ * @return  True if the set was successful, False if the set failed
+ *          due to wipe_block_tree_db incompatibility.
  */
-BITCOINKERNEL_API void kernel_chainstate_manager_options_set_wipe_chainstate_db(
+BITCOINKERNEL_API bool BITCOINKERNEL_WARN_UNUSED_RESULT kernel_chainstate_manager_options_set_wipe_chainstate_db(
     kernel_ChainstateManagerOptions* chainstate_manager_options,
     bool wipe_chainstate_db) BITCOINKERNEL_ARG_NONNULL(1);
 

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -398,6 +398,16 @@ public:
     {
     }
 
+    void SetWipeChainstateDb(bool wipe_chainstate) const noexcept
+    {
+        kernel_chainstate_manager_options_set_wipe_chainstate_db(m_options.get(), wipe_chainstate);
+    }
+
+    void SetChainstateDbInMemory(bool chainstate_db_in_memory) const noexcept
+    {
+        kernel_chainstate_manager_options_set_chainstate_db_in_memory(m_options.get(), chainstate_db_in_memory);
+    }
+
     void SetWorkerThreads(int worker_threads) const noexcept
     {
         kernel_chainstate_manager_options_set_worker_threads_num(m_options.get(), worker_threads);
@@ -439,37 +449,6 @@ public:
 
     /** Check whether this BlockManagerOptions object is valid. */
     explicit operator bool() const noexcept { return bool{m_options}; }
-
-    friend class ChainMan;
-};
-
-class ChainstateLoadOptions
-{
-private:
-    struct Deleter {
-        void operator()(kernel_ChainstateLoadOptions* ptr) const
-        {
-            kernel_chainstate_load_options_destroy(ptr);
-        }
-    };
-
-    const std::unique_ptr<kernel_ChainstateLoadOptions, Deleter> m_options;
-
-public:
-    ChainstateLoadOptions() noexcept
-        : m_options{kernel_chainstate_load_options_create()}
-    {
-    }
-
-    void SetWipeChainstateDb(bool wipe_chainstate) const noexcept
-    {
-        kernel_chainstate_load_options_set_wipe_chainstate_db(m_options.get(), wipe_chainstate);
-    }
-
-    void SetChainstateDbInMemory(bool chainstate_db_in_memory) const noexcept
-    {
-        kernel_chainstate_load_options_set_chainstate_db_in_memory(m_options.get(), chainstate_db_in_memory);
-    }
 
     friend class ChainMan;
 };
@@ -606,12 +585,11 @@ private:
     const Context& m_context;
 
 public:
-    ChainMan(const Context& context, const ChainstateManagerOptions& chainman_opts, const BlockManagerOptions& blockman_opts, ChainstateLoadOptions& chainstate_load_opts) noexcept
+    ChainMan(const Context& context, const ChainstateManagerOptions& chainman_opts, const BlockManagerOptions& blockman_opts) noexcept
         : m_chainman{kernel_chainstate_manager_create(
-                context.m_context.get(),
-                chainman_opts.m_options.get(),
-                blockman_opts.m_options.get(),
-                chainstate_load_opts.m_options.get())},
+              context.m_context.get(),
+              chainman_opts.m_options.get(),
+              blockman_opts.m_options.get())},
           m_context{context}
     {
     }

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -393,9 +393,22 @@ private:
     std::unique_ptr<kernel_ChainstateManagerOptions, Deleter> m_options;
 
 public:
-    ChainstateManagerOptions(const Context& context, const std::string& data_dir) noexcept
-        : m_options{kernel_chainstate_manager_options_create(context.m_context.get(), data_dir.c_str(), data_dir.length())}
+    ChainstateManagerOptions(const Context& context, const std::string& data_dir, const std::string& blocks_dir) noexcept
+        : m_options{kernel_chainstate_manager_options_create(
+              context.m_context.get(),
+              data_dir.c_str(), data_dir.length(),
+              blocks_dir.c_str(), blocks_dir.length())}
     {
+    }
+
+    void SetWipeBlockTreeDb(bool wipe_block_tree) const noexcept
+    {
+        kernel_chainstate_manager_options_set_wipe_block_tree_db(m_options.get(), wipe_block_tree);
+    }
+
+    void SetBlockTreeDbInMemory(bool block_tree_db_in_memory) const noexcept
+    {
+        kernel_chainstate_manager_options_set_block_tree_db_in_memory(m_options.get(), block_tree_db_in_memory);
     }
 
     void SetWipeChainstateDb(bool wipe_chainstate) const noexcept
@@ -414,40 +427,6 @@ public:
     }
 
     /** Check whether this ChainstateManagerOptions object is valid. */
-    explicit operator bool() const noexcept { return bool{m_options}; }
-
-    friend class ChainMan;
-};
-
-class BlockManagerOptions
-{
-private:
-    struct Deleter {
-        void operator()(kernel_BlockManagerOptions* ptr) const
-        {
-            kernel_block_manager_options_destroy(ptr);
-        }
-    };
-
-    std::unique_ptr<kernel_BlockManagerOptions, Deleter> m_options;
-
-public:
-    BlockManagerOptions(const Context& context, const std::string& data_dir, const std::string& blocks_dir) noexcept
-        : m_options{kernel_block_manager_options_create(context.m_context.get(), data_dir.c_str(), data_dir.length(), blocks_dir.c_str(), blocks_dir.length())}
-    {
-    }
-
-    void SetWipeBlockTreeDb(bool wipe_block_tree) const noexcept
-    {
-        kernel_block_manager_options_set_wipe_block_tree_db(m_options.get(), wipe_block_tree);
-    }
-
-    void SetBlockTreeDbInMemory(bool block_tree_db_in_memory) const noexcept
-    {
-        kernel_block_manager_options_set_block_tree_db_in_memory(m_options.get(), block_tree_db_in_memory);
-    }
-
-    /** Check whether this BlockManagerOptions object is valid. */
     explicit operator bool() const noexcept { return bool{m_options}; }
 
     friend class ChainMan;
@@ -585,11 +564,10 @@ private:
     const Context& m_context;
 
 public:
-    ChainMan(const Context& context, const ChainstateManagerOptions& chainman_opts, const BlockManagerOptions& blockman_opts) noexcept
+    ChainMan(const Context& context, const ChainstateManagerOptions& chainman_opts) noexcept
         : m_chainman{kernel_chainstate_manager_create(
               context.m_context.get(),
-              chainman_opts.m_options.get(),
-              blockman_opts.m_options.get())},
+              chainman_opts.m_options.get())},
           m_context{context}
     {
     }

--- a/src/kernel/bitcoinkernel_wrapper.h
+++ b/src/kernel/bitcoinkernel_wrapper.h
@@ -401,9 +401,9 @@ public:
     {
     }
 
-    void SetWipeBlockTreeDb(bool wipe_block_tree) const noexcept
+    bool SetWipeBlockTreeDb(bool wipe_block_tree) const noexcept
     {
-        kernel_chainstate_manager_options_set_wipe_block_tree_db(m_options.get(), wipe_block_tree);
+        return kernel_chainstate_manager_options_set_wipe_block_tree_db(m_options.get(), wipe_block_tree);
     }
 
     void SetBlockTreeDbInMemory(bool block_tree_db_in_memory) const noexcept
@@ -411,9 +411,9 @@ public:
         kernel_chainstate_manager_options_set_block_tree_db_in_memory(m_options.get(), block_tree_db_in_memory);
     }
 
-    void SetWipeChainstateDb(bool wipe_chainstate) const noexcept
+    bool SetWipeChainstateDb(bool wipe_chainstate) const noexcept
     {
-        kernel_chainstate_manager_options_set_wipe_chainstate_db(m_options.get(), wipe_chainstate);
+        return kernel_chainstate_manager_options_set_wipe_chainstate_db(m_options.get(), wipe_chainstate);
     }
 
     void SetChainstateDbInMemory(bool chainstate_db_in_memory) const noexcept

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -375,6 +375,7 @@ void chainman_test()
 
     ChainstateManagerOptions chainman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
     assert(chainman_opts);
+    assert(!chainman_opts.SetWipeBlockTreeDb(true)); // Can't set wipe_block_tree_db to true when wipe_chainstate_db is false
     chainman_opts.SetWorkerThreads(4);
 
     ChainMan chainman{context, chainman_opts};
@@ -392,11 +393,11 @@ std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
     assert(chainman_opts);
 
     if (reindex) {
-        chainman_opts.SetWipeBlockTreeDb(reindex);
-        chainman_opts.SetWipeChainstateDb(reindex);
+        assert(chainman_opts.SetWipeChainstateDb(reindex));
+        assert(chainman_opts.SetWipeBlockTreeDb(reindex));
     }
     if (wipe_chainstate) {
-        chainman_opts.SetWipeChainstateDb(wipe_chainstate);
+        assert(chainman_opts.SetWipeChainstateDb(wipe_chainstate));
     }
     if (block_tree_db_in_memory) {
         chainman_opts.SetBlockTreeDbInMemory(block_tree_db_in_memory);

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -373,13 +373,11 @@ void chainman_test()
     TestKernelNotifications notifications{};
     auto context{create_context(notifications, kernel_ChainType::kernel_CHAIN_TYPE_MAINNET)};
 
-    ChainstateManagerOptions chainman_opts{context, test_directory.m_directory.string()};
+    ChainstateManagerOptions chainman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
     assert(chainman_opts);
     chainman_opts.SetWorkerThreads(4);
-    BlockManagerOptions blockman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
-    assert(blockman_opts);
 
-    ChainMan chainman{context, chainman_opts, blockman_opts};
+    ChainMan chainman{context, chainman_opts};
     assert(chainman);
 }
 
@@ -390,26 +388,24 @@ std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
                                           bool chainstate_db_in_memory,
                                           Context& context)
 {
-    ChainstateManagerOptions chainman_opts{context, test_directory.m_directory.string()};
+    ChainstateManagerOptions chainman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
     assert(chainman_opts);
-    BlockManagerOptions blockman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
-    assert(blockman_opts);
 
     if (reindex) {
-        blockman_opts.SetWipeBlockTreeDb(reindex);
+        chainman_opts.SetWipeBlockTreeDb(reindex);
         chainman_opts.SetWipeChainstateDb(reindex);
     }
     if (wipe_chainstate) {
         chainman_opts.SetWipeChainstateDb(wipe_chainstate);
     }
     if (block_tree_db_in_memory) {
-        blockman_opts.SetBlockTreeDbInMemory(block_tree_db_in_memory);
+        chainman_opts.SetBlockTreeDbInMemory(block_tree_db_in_memory);
     }
     if (chainstate_db_in_memory) {
         chainman_opts.SetChainstateDbInMemory(chainstate_db_in_memory);
     }
 
-    auto chainman{std::make_unique<ChainMan>(context, chainman_opts, blockman_opts)};
+    auto chainman{std::make_unique<ChainMan>(context, chainman_opts)};
     assert(chainman);
     return chainman;
 }

--- a/src/test/kernel/test_kernel.cpp
+++ b/src/test/kernel/test_kernel.cpp
@@ -378,9 +378,8 @@ void chainman_test()
     chainman_opts.SetWorkerThreads(4);
     BlockManagerOptions blockman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
     assert(blockman_opts);
-    ChainstateLoadOptions chainstate_load_opts{};
 
-    ChainMan chainman{context, chainman_opts, blockman_opts, chainstate_load_opts};
+    ChainMan chainman{context, chainman_opts, blockman_opts};
     assert(chainman);
 }
 
@@ -395,23 +394,22 @@ std::unique_ptr<ChainMan> create_chainman(TestDirectory& test_directory,
     assert(chainman_opts);
     BlockManagerOptions blockman_opts{context, test_directory.m_directory.string(), (test_directory.m_directory / "blocks").string()};
     assert(blockman_opts);
-    ChainstateLoadOptions chainstate_load_opts{};
 
     if (reindex) {
         blockman_opts.SetWipeBlockTreeDb(reindex);
-        chainstate_load_opts.SetWipeChainstateDb(reindex);
+        chainman_opts.SetWipeChainstateDb(reindex);
     }
     if (wipe_chainstate) {
-        chainstate_load_opts.SetWipeChainstateDb(wipe_chainstate);
+        chainman_opts.SetWipeChainstateDb(wipe_chainstate);
     }
     if (block_tree_db_in_memory) {
         blockman_opts.SetBlockTreeDbInMemory(block_tree_db_in_memory);
     }
     if (chainstate_db_in_memory) {
-        chainstate_load_opts.SetChainstateDbInMemory(chainstate_db_in_memory);
+        chainman_opts.SetChainstateDbInMemory(chainstate_db_in_memory);
     }
 
-    auto chainman{std::make_unique<ChainMan>(context, chainman_opts, blockman_opts, chainstate_load_opts)};
+    auto chainman{std::make_unique<ChainMan>(context, chainman_opts, blockman_opts)};
     assert(chainman);
     return chainman;
 }


### PR DESCRIPTION
This PR addresses two concerns I've been having over the past weeks using the kernel API:
1) It's not ergonomic to force the user inspect the logs to understand why `kernel_chainstate_manager_create` fails when `set_wipe_block_tree_db` was set to `True` and `set_wipe_chainstate_db` to `False`.
2) the kernel API does not expose any `BlockManager` or `ChainstateLoad` functionality, yet the user must instantiate `Options` objects for it.

Fix both issues by merging all `kernel_BlockManagerOptions` and `kernel_ChainstateLoadOptions` functionality into `kernel_ChainstateManagerOptions` (introducing a new, internal `ChainstateManagerOptionsWrapper` struct), which allows both `wipe` setters to inspect the other, and return whether or not the operation was valid. This should be a lot more ergonomic than `kernel_chainstate_manager_create` just returning a `nullptr`, which can happen because of many reasons.

A couple of thoughts:
- The new `chainstate_manager_options_*_wipe_*` functions can be a little awkward to use. For example, when both `wipe` options need to be set to True, you can only do it by first setting `chainstate`. While not ideal, I think a clunky but correct-by-construction API is better than an easier-to-use, but also easier-to-abuse (and harder to understand) API?
- I understand that the current `wipe` options approach is suboptimal and may be removed in future force-pushes anyway, but I think merging the `Options` objects is an improvement regardless?
- I think introducing a `kernel_BlockManager` is on the roadmap, but I expect this won't be in the very short term. Imo, it makes more sense to introduce the `Options` object when we actually need it, with the layout that makes most sense at that time? And when that happens, I suspect we'll have to make some changes anyway (e.g., I think `BlockManagerOptions` should probably be a `ChainstateManagerOptions` member)
- Merging the options objects also removes the duplicated `datadir` setting, so they can't be set to different values anymore.